### PR TITLE
refactor(filters): change the signature of FeedFilterConfig::build

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -21,7 +21,7 @@ pub trait FeedFilter {
 pub trait FeedFilterConfig: DeserializeOwned {
   type Filter: FeedFilter;
 
-  async fn build(&self) -> Result<Self::Filter>;
+  async fn build(self) -> Result<Self::Filter>;
 }
 
 #[derive(Clone)]
@@ -54,7 +54,7 @@ macro_rules! define_filters {
     }
 
     impl FilterConfig {
-      pub async fn build(&self) -> Result<BoxedFilter> {
+      pub async fn build(self) -> Result<BoxedFilter> {
         match self {
           $(FilterConfig::$variant(config) => {
             let filter = config.build().await?;

--- a/src/filter/full_text.rs
+++ b/src/filter/full_text.rs
@@ -35,15 +35,15 @@ pub struct FullTextFilter {
 impl FeedFilterConfig for FullTextConfig {
   type Filter = FullTextFilter;
 
-  async fn build(&self) -> Result<Self::Filter> {
-    let client = self.client.clone().unwrap_or_default().build()?;
+  async fn build(self) -> Result<Self::Filter> {
+    let client = self.client.unwrap_or_default().build()?;
     let parallelism = self.parallelism.unwrap_or(DEFAULT_PARALLELISM);
     let append_mode = self.append_mode.unwrap_or(false);
     let simplify = self.simplify.unwrap_or(false);
     let keep_guid = self.keep_guid.unwrap_or(false);
     let keep_element = match self.keep_element {
       None => None,
-      Some(ref c) => Some(c.build().await?),
+      Some(c) => Some(c.build().await?),
     };
 
     Ok(FullTextFilter {

--- a/src/filter/html.rs
+++ b/src/filter/html.rs
@@ -49,10 +49,10 @@ fn parse_selector(selector: &str) -> Result<Selector> {
 impl FeedFilterConfig for RemoveElementConfig {
   type Filter = RemoveElement;
 
-  async fn build(&self) -> Result<Self::Filter> {
+  async fn build(self) -> Result<Self::Filter> {
     let mut selectors = vec![];
-    for selector in &self.selectors {
-      let parsed = parse_selector(selector)?;
+    for selector in self.selectors {
+      let parsed = parse_selector(&selector)?;
 
       selectors.push(parsed);
     }
@@ -115,7 +115,7 @@ impl FeedFilterConfig for KeepElementConfig {
   // TODO: decide whether we want to support iteratively narrowed
   // selector. Multiple selectors here may create more confusion than
   // being useful.
-  async fn build(&self) -> Result<Self::Filter> {
+  async fn build(self) -> Result<Self::Filter> {
     let selectors = vec![parse_selector(&self.selector)?];
     Ok(KeepElement { selectors })
   }
@@ -194,7 +194,7 @@ pub struct Split {
 impl FeedFilterConfig for SplitConfig {
   type Filter = Split;
 
-  async fn build(&self) -> Result<Self::Filter> {
+  async fn build(self) -> Result<Self::Filter> {
     let parse_selector_opt = |s: &Option<String>| -> Result<Option<Selector>> {
       match s {
         Some(s) => Ok(Some(parse_selector(s)?)),

--- a/src/filter/html.rs
+++ b/src/filter/html.rs
@@ -39,6 +39,7 @@ pub struct RemoveElement {
   selectors: Vec<Selector>,
 }
 
+// can't define FromStr for Selector due to Rust's orphan rule
 fn parse_selector(selector: &str) -> Result<Selector> {
   Selector::parse(selector)
     .map_err(|e| ConfigError::BadSelector(format!("{}: {}", selector, e)))

--- a/src/filter/js.rs
+++ b/src/filter/js.rs
@@ -21,7 +21,7 @@ pub struct JsFilter {
 impl FeedFilterConfig for JsConfig {
   type Filter = JsFilter;
 
-  async fn build(&self) -> Result<Self::Filter> {
+  async fn build(self) -> Result<Self::Filter> {
     let runtime = Runtime::new().await?;
     runtime.eval(&self.code).await?;
 

--- a/src/filter/sanitize.rs
+++ b/src/filter/sanitize.rs
@@ -87,9 +87,9 @@ pub struct Sanitize {
 impl FeedFilterConfig for SanitizeConfig {
   type Filter = Sanitize;
 
-  async fn build(&self) -> Result<Self::Filter> {
+  async fn build(self) -> Result<Self::Filter> {
     let mut ops = Vec::new();
-    for op in &self.ops {
+    for op in self.ops {
       ops.push(op.parse()?);
     }
 

--- a/src/filter/select.rs
+++ b/src/filter/select.rs
@@ -128,7 +128,7 @@ enum Action {
 impl FeedFilterConfig for KeepOnlyConfig {
   type Filter = Select;
 
-  async fn build(&self) -> Result<Self::Filter> {
+  async fn build(self) -> Result<Self::Filter> {
     self.0.to_match_config().to_select(Action::Include)
   }
 }
@@ -137,7 +137,7 @@ impl FeedFilterConfig for KeepOnlyConfig {
 impl FeedFilterConfig for DiscardConfig {
   type Filter = Select;
 
-  async fn build(&self) -> Result<Self::Filter> {
+  async fn build(self) -> Result<Self::Filter> {
     self.0.to_match_config().to_select(Action::Exclude)
   }
 }

--- a/src/filter/select.rs
+++ b/src/filter/select.rs
@@ -45,17 +45,17 @@ impl Default for MatchConfig {
 }
 
 impl AnyMatchConfig {
-  fn to_match_config(&self) -> MatchConfig {
+  fn into_match_config(self) -> MatchConfig {
     match self {
       Self::SingleContains(s) => MatchConfig {
-        contains: SingleOrVec::Vec(vec![s.clone()]),
+        contains: SingleOrVec::Vec(vec![s]),
         ..Default::default()
       },
       Self::MultipleContains(v) => MatchConfig {
-        contains: SingleOrVec::Vec(v.clone()),
+        contains: SingleOrVec::Vec(v),
         ..Default::default()
       },
-      Self::MatchConfig(m) => m.clone(),
+      Self::MatchConfig(m) => m,
     }
   }
 }
@@ -78,7 +78,7 @@ impl MatchConfig {
     Ok(RegexSet::new(self.regexes()).map_err(ConfigError::from)?)
   }
 
-  fn to_select(&self, action: Action) -> Result<Select> {
+  fn into_select(self, action: Action) -> Result<Select> {
     let needle = self.regex_set()?;
     let field = self.field;
 
@@ -129,7 +129,7 @@ impl FeedFilterConfig for KeepOnlyConfig {
   type Filter = Select;
 
   async fn build(self) -> Result<Self::Filter> {
-    self.0.to_match_config().to_select(Action::Include)
+    self.0.into_match_config().into_select(Action::Include)
   }
 }
 
@@ -138,7 +138,7 @@ impl FeedFilterConfig for DiscardConfig {
   type Filter = Select;
 
   async fn build(self) -> Result<Self::Filter> {
-    self.0.to_match_config().to_select(Action::Exclude)
+    self.0.into_match_config().into_select(Action::Exclude)
   }
 }
 

--- a/src/filter/simplify_html.rs
+++ b/src/filter/simplify_html.rs
@@ -15,7 +15,7 @@ pub struct SimplifyHtmlFilter;
 impl FeedFilterConfig for SimplifyHtmlConfig {
   type Filter = SimplifyHtmlFilter;
 
-  async fn build(&self) -> Result<Self::Filter> {
+  async fn build(self) -> Result<Self::Filter> {
     Ok(SimplifyHtmlFilter)
   }
 }


### PR DESCRIPTION
This PR changes the signature of the trait from:

``` rust
pub trait FeedFilterConfig: DeserializeOwned {
  type Filter: FeedFilter;

  async fn build(&self) -> Result<Self::Filter>;
}
```

to:

``` rust
pub trait FeedFilterConfig: DeserializeOwned {
  type Filter: FeedFilter;

  async fn build(self) -> Result<Self::Filter>;
}
```

The main reason to make the change is because the latter makes more sense. The config is supposed to be consumed when built into a filter. The former signature is confusing because it implies that the config may be used for other purpose after the build, or that the config may be built into a filter repeatedly. Either implication is not true about the expected use of the type.