### PR TITLE
feat(client): Caching requests to servers for feed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
 name = "anstream"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,6 +782,10 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -1092,6 +1102,15 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "lru"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2c024b41519440580066ba82aab04092b333e09066a5eb86c7c4890df31f22"
+dependencies = [
+ "hashbrown 0.14.3",
+]
 
 [[package]]
 name = "lru-cache"
@@ -1881,6 +1900,7 @@ dependencies = [
  "http 1.0.0",
  "itertools",
  "lazy_static",
+ "lru",
  "mime",
  "paste",
  "readability",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1894,6 +1894,7 @@ dependencies = [
  "duration-str",
  "ego-tree",
  "either",
+ "encoding_rs",
  "futures",
  "html5ever",
  "htmlescape",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ tracing = { version = "0.1.40"}
 tracing-subscriber = "0.3.18"
 lazy_static = "1.4.0"
 serde_regex = "1.1.0"
+lru = "0.12.2"
 
 [patch.crates-io]
 ego-tree = { git = "https://github.com/shouya/ego-tree.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,8 @@ either = "1.9.0" # used for returning sum types from the JS runtime
 # Web client (blocking and async both used, blocking used in the JS runtime)
 # TODO: upgrade reqwest after its hyper 1.0 upgrade
 reqwest = { version = "0.11.23", default-features = false, features = ["blocking", "rustls-tls", "trust-dns"] }
+encoding_rs = "0.8.33"
+lru = "0.12.2"
 
 # Used in sanitize filter to remove/replace text contents
 regex = "1.10.2"
@@ -58,7 +60,6 @@ tracing = { version = "0.1.40"}
 tracing-subscriber = "0.3.18"
 lazy_static = "1.4.0"
 serde_regex = "1.1.0"
-lru = "0.12.2"
 
 [patch.crates-io]
 ego-tree = { git = "https://github.com/shouya/ego-tree.git" }

--- a/src/client.rs
+++ b/src/client.rs
@@ -17,9 +17,8 @@ pub struct ClientConfig {
   set_cookie: Option<String>,
   referer: Option<String>,
   cache_size: Option<usize>,
-  #[serde(deserialize_with = "duration_str::deserialize_duration")]
-  #[serde(default = "default_cache_ttl")]
-  cache_ttl: Duration,
+  #[serde(deserialize_with = "duration_str::deserialize_option_duration")]
+  cache_ttl: Option<Duration>,
   #[serde(default = "default_timeout")]
   #[serde(deserialize_with = "duration_str::deserialize_duration")]
   timeout: Duration,
@@ -34,7 +33,7 @@ impl Default for ClientConfig {
       referer: None,
       timeout: default_timeout(),
       cache_size: None,
-      cache_ttl: default_cache_ttl(),
+      cache_ttl: None,
     }
   }
 }
@@ -78,11 +77,11 @@ impl ClientConfig {
     builder
   }
 
-  pub fn build(&self) -> Result<Client> {
+  pub fn build(&self, default_cache_ttl: Duration) -> Result<Client> {
     let reqwest_client = self.to_builder().build()?;
     Ok(Client::new(
       self.cache_size.unwrap_or(0),
-      self.cache_ttl,
+      self.cache_ttl.unwrap_or(default_cache_ttl),
       reqwest_client,
     ))
   }
@@ -127,8 +126,4 @@ impl Client {
 
 fn default_timeout() -> Duration {
   Duration::from_secs(10)
-}
-
-fn default_cache_ttl() -> Duration {
-  Duration::from_secs(10 * 60)
 }

--- a/src/client/cache.rs
+++ b/src/client/cache.rs
@@ -82,6 +82,23 @@ impl Response {
     })
   }
 
+  #[cfg(test)]
+  pub fn new(
+    url: Url,
+    status: reqwest::StatusCode,
+    headers: HeaderMap,
+    body: Box<[u8]>,
+  ) -> Self {
+    Self {
+      inner: Arc::new(InnerResponse {
+        url,
+        status,
+        headers,
+        body,
+      }),
+    }
+  }
+
   pub fn error_for_status(self) -> Result<Self> {
     let status = self.inner.status;
     if status.is_client_error() || status.is_server_error() {
@@ -117,5 +134,18 @@ impl Response {
 
   pub fn content_type(&self) -> Option<Mime> {
     self.header("content-type").and_then(|v| v.parse().ok())
+  }
+
+  pub fn url(&self) -> &Url {
+    &self.inner.url
+  }
+  pub fn status(&self) -> reqwest::StatusCode {
+    self.inner.status
+  }
+  pub fn headers(&self) -> &HeaderMap {
+    &self.inner.headers
+  }
+  pub fn body(&self) -> &[u8] {
+    &self.inner.body
   }
 }

--- a/src/client/cache.rs
+++ b/src/client/cache.rs
@@ -1,0 +1,79 @@
+use std::{
+  num::NonZeroUsize,
+  sync::{Arc, RwLock},
+  time::{Duration, Instant},
+};
+
+use lru::LruCache;
+use reqwest::header::HeaderMap;
+use url::Url;
+
+use crate::util::Result;
+
+struct Timed<T> {
+  value: T,
+  created: Instant,
+}
+
+pub struct ResponseCache {
+  map: RwLock<LruCache<Url, Timed<Response>>>,
+  timeout: Duration,
+}
+
+impl ResponseCache {
+  pub fn new(max_entries: usize, timeout: Duration) -> Self {
+    let max_entries = max_entries.try_into().unwrap_or(NonZeroUsize::MIN);
+    Self {
+      map: RwLock::new(LruCache::new(max_entries)),
+      timeout,
+    }
+  }
+
+  pub fn get_cached(&self, url: &Url) -> Option<Response> {
+    let mut map = self.map.write().ok()?;
+    let Some(entry) = map.get(url) else {
+      return None;
+    };
+    if entry.created.elapsed() > self.timeout {
+      map.pop(url);
+      return None;
+    }
+    Some(entry.value.clone())
+  }
+
+  pub fn insert(&self, url: Url, response: Response) -> Option<()> {
+    let timed = Timed {
+      value: response,
+      created: Instant::now(),
+    };
+    self.map.write().ok()?.push(url, timed);
+    Some(())
+  }
+}
+
+#[derive(Clone)]
+pub struct Response {
+  inner: Arc<InnerResponse>,
+}
+
+struct InnerResponse {
+  status: reqwest::StatusCode,
+  headers: HeaderMap,
+  body: Box<[u8]>,
+}
+
+impl Response {
+  pub async fn from_reqwest_resp(resp: reqwest::Response) -> Result<Self> {
+    let status = resp.status();
+    let headers = resp.headers().clone();
+    let body = resp.bytes().await?.to_vec().into_boxed_slice();
+
+    Ok(Self {
+      inner: Arc::new(InnerResponse {
+        status,
+        headers,
+        body,
+      }),
+    })
+  }
+}

--- a/src/filter/full_text.rs
+++ b/src/filter/full_text.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use futures::{stream, StreamExt};
 
 use serde::{Deserialize, Serialize};
@@ -37,7 +39,9 @@ impl FeedFilterConfig for FullTextConfig {
   type Filter = FullTextFilter;
 
   async fn build(self) -> Result<Self::Filter> {
-    let client = self.client.unwrap_or_default().build()?;
+    // default cache ttl is 12 hours
+    let default_cache_ttl = Duration::from_secs(12 * 60 * 60);
+    let client = self.client.unwrap_or_default().build(default_cache_ttl)?;
     let parallelism = self.parallelism.unwrap_or(DEFAULT_PARALLELISM);
     let append_mode = self.append_mode.unwrap_or(false);
     let simplify = self.simplify.unwrap_or(false);

--- a/src/filter/full_text.rs
+++ b/src/filter/full_text.rs
@@ -1,8 +1,9 @@
 use futures::{stream, StreamExt};
-use mime::Mime;
-use serde::{Deserialize, Serialize};
 
-use crate::client;
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::client::{self, Client};
 use crate::feed::{Feed, Post};
 use crate::html::convert_relative_url;
 use crate::util::{Error, Result};
@@ -23,7 +24,7 @@ pub struct FullTextConfig {
 }
 
 pub struct FullTextFilter {
-  client: reqwest::Client,
+  client: Client,
   parallelism: usize,
   append_mode: bool,
   keep_element: Option<KeepElement>,
@@ -59,14 +60,9 @@ impl FeedFilterConfig for FullTextConfig {
 
 impl FullTextFilter {
   async fn fetch_html(&self, url: &str) -> Result<String> {
-    let resp = self.client.get(url).send().await?;
-    let content_type = resp
-      .headers()
-      .get("content-type")
-      .and_then(|v| v.to_str().ok())
-      .unwrap_or("text/html")
-      .parse::<Mime>()
-      .map_err(|_| Error::Message("invalid content_type".to_string()))?;
+    let url = Url::parse(url)?;
+    let resp = self.client.get(&url).await?;
+    let content_type = resp.content_type().unwrap_or(mime::TEXT_HTML);
 
     if content_type.essence_str() != "text/html" {
       return Err(Error::Message(format!(
@@ -76,7 +72,7 @@ impl FullTextFilter {
     }
 
     let resp = resp.error_for_status()?;
-    let text = resp.text().await?;
+    let text = resp.text()?;
 
     Ok(text)
   }

--- a/src/filter/simplify_html.rs
+++ b/src/filter/simplify_html.rs
@@ -1,5 +1,6 @@
 use readability::extractor::extract;
 use serde::{Deserialize, Serialize};
+use url::Url;
 
 use crate::feed::Feed;
 use crate::util::Result;
@@ -40,7 +41,7 @@ impl FeedFilter for SimplifyHtmlFilter {
 }
 
 pub(super) fn simplify(text: &str, url: &str) -> Option<String> {
-  let url = reqwest::Url::parse(url).ok()?;
+  let url = Url::parse(url).ok()?;
   let mut text = std::io::Cursor::new(text);
   let product = extract(&mut text, &url).ok()?;
   Some(product.content)

--- a/src/server/endpoint.rs
+++ b/src/server/endpoint.rs
@@ -2,6 +2,7 @@ use std::convert::Infallible;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::body::Body;
 use axum::response::IntoResponse;
@@ -212,7 +213,8 @@ impl EndpointService {
       filters.push(filter);
     }
 
-    let client = config.client.unwrap_or_default().build()?;
+    let default_cache_ttl = Duration::from_secs(15 * 60);
+    let client = config.client.unwrap_or_default().build(default_cache_ttl)?;
     let source = match config.source {
       Some(source) => Some(Url::parse(&source)?),
       None => None,

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use url::Url;
 
 pub const USER_AGENT: &str =
   concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
@@ -46,6 +47,9 @@ pub enum Error {
 
   #[error("Reqwest client error {0:?}")]
   Reqwest(#[from] reqwest::Error),
+
+  #[error("HTTP status error {0:?} (url: {1})")]
+  HttpStatus(reqwest::StatusCode, Url),
 
   #[error("Js execution error {0:?}")]
   Js(#[from] rquickjs::Error),


### PR DESCRIPTION
This PR implements a client that caches the get requests to the servers when fetching feeds. It is used in places where `reqwest::Client` is used. Currently there are two places:

- the client used to fetch the source (default ttl: 15 minutes)
- the full_text filter (default ttl: 12 hours)

This mechanism is expected to help in speeding up the fetching of feeds especially for repeated full-text requests.

I'm also planning to employ this cache tests to insert custom fixtures for certain web addresses for future feature tests.