### PR TITLE
fix(config)!: change content_type from endpoint config

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -30,6 +30,9 @@ pub struct ClientConfig {
   #[serde(default = "default_timeout")]
   #[serde(deserialize_with = "duration_str::deserialize_duration")]
   timeout: Duration,
+  /// Sometimes the feed doesn't specify a
+  #[serde(default)]
+  assume_content_type: Option<String>,
 }
 
 impl Default for ClientConfig {
@@ -42,6 +45,7 @@ impl Default for ClientConfig {
       timeout: default_timeout(),
       cache_size: None,
       cache_ttl: None,
+      assume_content_type: None,
     }
   }
 }
@@ -91,6 +95,7 @@ impl ClientConfig {
       self.cache_size.unwrap_or(0),
       self.cache_ttl.unwrap_or(default_cache_ttl),
       reqwest_client,
+      self.assume_content_type.clone(),
     );
     Ok(client)
   }
@@ -99,6 +104,7 @@ impl ClientConfig {
 pub struct Client {
   cache: ResponseCache,
   client: reqwest::Client,
+  assume_content_type: Option<String>,
 }
 
 impl Client {
@@ -106,10 +112,12 @@ impl Client {
     cache_size: usize,
     cache_ttl: Duration,
     client: reqwest::Client,
+    assume_content_type: Option<String>,
   ) -> Self {
     Self {
       cache: ResponseCache::new(cache_size, cache_ttl),
       client,
+      assume_content_type,
     }
   }
 
@@ -128,8 +136,18 @@ impl Client {
 
     let resp = f(self.client.get(url.clone())).send().await?;
     let resp = Response::from_reqwest_resp(resp).await?;
+    let resp = self.modify_resp(resp);
     self.cache.insert(url.clone(), resp.clone());
     Ok(resp)
+  }
+
+  fn modify_resp(&self, mut resp: Response) -> Response {
+    let Some(assume_content_type) = &self.assume_content_type else {
+      return resp;
+    };
+
+    resp.set_content_type(assume_content_type);
+    resp
   }
 
   #[cfg(test)]
@@ -155,7 +173,8 @@ mod tests {
 
   #[tokio::test]
   async fn test_client_cache() {
-    let client = Client::new(1, Duration::from_secs(1), reqwest::Client::new());
+    let client =
+      Client::new(1, Duration::from_secs(1), reqwest::Client::new(), None);
     let url = Url::parse("http://example.com").unwrap();
     let body: Box<str> = "foo".into();
     let response = Response::new(
@@ -179,7 +198,8 @@ mod tests {
 
   #[tokio::test]
   async fn test_client() {
-    let client = Client::new(0, Duration::from_secs(1), reqwest::Client::new());
+    let client =
+      Client::new(0, Duration::from_secs(1), reqwest::Client::new(), None);
     let url = Url::parse(YT_SCISHOW_FEED_URL).unwrap();
     let resp = client.get(&url).await.unwrap();
     assert_eq!(resp.status(), reqwest::StatusCode::OK);

--- a/src/client/cache.rs
+++ b/src/client/cache.rs
@@ -155,6 +155,16 @@ impl Response {
     self.header("content-type").and_then(|v| v.parse().ok())
   }
 
+  // can only be called the first time the response is constructed
+  pub(super) fn set_content_type(&mut self, content_type: &str) {
+    let inner = Arc::get_mut(&mut self.inner).expect("response is shared");
+
+    inner.headers.insert(
+      "content-type",
+      content_type.parse().expect("invalid content_type"),
+    );
+  }
+
   #[allow(dead_code)]
   pub fn url(&self) -> &Url {
     &self.inner.url


### PR DESCRIPTION
Previously the `content_type` in endpoint config is used to enforce the interpretation of the request body in a certain content type. This feature is useful on some feeds that reports wrong content types.

Later I discovered that this feature is more generally needed. For example, in the upcoming merge filter, we may also want to assume the content_type for the merged source. So in this PR, I moved the `content_type` field from endpoint's config to the client's config. I also renamed it to `assume_content_type` to make it more clear.

BREAKING CHANGE: This change will break the existing configuration if you use `content_type` field in an endpoint. You need to update your endpoint config as follows:

``` yaml
# old
endpoints:
  - path: /foo
    source: http://website/feed.xml
    content_type: application/atom+xml
    filters: ...

# new
endpoints:
  - path: /foo
    source: http://website/feed.xml
    client:
      assume_content_type: application/atom+xml
    filters: ...
```