### PR TITLE
feat(filters): new `merge_feed` filter

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -6,7 +6,7 @@ use reqwest::header::HeaderMap;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-use crate::util::Result;
+use crate::{feed::Feed, util::Result};
 
 use self::cache::{Response, ResponseCache};
 
@@ -119,6 +119,29 @@ impl Client {
       client,
       assume_content_type,
     }
+  }
+
+  pub async fn fetch_feed(&self, source: &Url) -> Result<Feed> {
+    let resp = self
+      .get_with(source, |builder| {
+        builder.header("Accept", "text/html,application/xml")
+      })
+      .await?
+      .error_for_status()?;
+
+    let content_type = resp.content_type().map(|x| x.essence_str().to_owned());
+    let content = resp.text()?;
+
+    let feed = match content_type.as_deref() {
+      Some("text/html") => Feed::from_html_content(&content, source)?,
+      Some("application/xml")
+      | Some("text/xml")
+      | Some("application/rss+xml") => Feed::from_rss_content(&content)?,
+      Some("application/atom+xml") => Feed::from_atom_content(&content)?,
+      x => todo!("{:?}", x),
+    };
+
+    Ok(feed)
   }
 
   pub async fn get(&self, url: &Url) -> Result<Response> {

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -115,10 +115,10 @@ impl Feed {
         feed.entries.extend(other.entries);
       }
       (Feed::Rss(_), _) => {
-        return Err(Error::FeedParse("cannot merge atom into rss".into()));
+        return Err(Error::FeedMerge("cannot merge atom into rss"));
       }
       (Feed::Atom(_), _) => {
-        return Err(Error::FeedParse("cannot merge rss into atom".into()));
+        return Err(Error::FeedMerge("cannot merge rss into atom"));
       }
     }
 

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -105,6 +105,25 @@ impl Feed {
       Feed::Atom(feed) => feed.title.as_str(),
     }
   }
+
+  pub fn merge(&mut self, other: Feed) -> Result<()> {
+    match (self, other) {
+      (Feed::Rss(channel), Feed::Rss(other)) => {
+        channel.items.extend(other.items);
+      }
+      (Feed::Atom(feed), Feed::Atom(other)) => {
+        feed.entries.extend(other.entries);
+      }
+      (Feed::Rss(_), _) => {
+        return Err(Error::FeedParse("cannot merge atom into rss".into()));
+      }
+      (Feed::Atom(_), _) => {
+        return Err(Error::FeedParse("cannot merge rss into atom".into()));
+      }
+    }
+
+    Ok(())
+  }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -126,4 +126,5 @@ define_filters!(
   KeepOnly => select::KeepOnlyConfig;
   Discard => select::DiscardConfig;
   Highlight => highlight::HighlightConfig;
+  Merge => merge::MergeConfig;
 );

--- a/src/filter/merge.rs
+++ b/src/filter/merge.rs
@@ -105,7 +105,7 @@ mod test {
             filters:
               - js: |
                   function modify_post(feed, post) {
-                    post.title += " (modified)";
+                    post.title.value += " (modified)";
                     return post;
                   }
     "#;

--- a/src/filter/merge.rs
+++ b/src/filter/merge.rs
@@ -1,0 +1,89 @@
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::client::{Client, ClientConfig};
+use crate::feed::Feed;
+use crate::util::Result;
+
+use super::{FeedFilter, FeedFilterConfig, FilterConfig, Filters};
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum MergeConfig {
+  Simple(MergeSimpleConfig),
+  Full(MergeFullConfig),
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(transparent)]
+pub struct MergeSimpleConfig {
+  source: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct MergeFullConfig {
+  source: String,
+  #[serde(default)]
+  client: ClientConfig,
+  #[serde(default)]
+  filters: Vec<FilterConfig>,
+}
+
+impl From<MergeSimpleConfig> for MergeFullConfig {
+  fn from(config: MergeSimpleConfig) -> Self {
+    Self {
+      source: config.source,
+      client: ClientConfig::default(),
+      filters: Default::default(),
+    }
+  }
+}
+
+impl From<MergeConfig> for MergeFullConfig {
+  fn from(config: MergeConfig) -> Self {
+    match config {
+      MergeConfig::Simple(config) => config.into(),
+      MergeConfig::Full(config) => config,
+    }
+  }
+}
+
+#[async_trait::async_trait]
+impl FeedFilterConfig for MergeConfig {
+  type Filter = Merge;
+
+  async fn build(self) -> Result<Self::Filter> {
+    let MergeFullConfig {
+      client,
+      filters,
+      source,
+    } = self.into();
+    let client = client.build(Duration::from_secs(15 * 60))?;
+    let filters = Filters::from_config(filters).await?;
+    let source = Url::parse(&source)?;
+
+    Ok(Merge {
+      client,
+      source,
+      filters,
+    })
+  }
+}
+
+pub struct Merge {
+  client: Client,
+  source: Url,
+  filters: Filters,
+}
+
+#[async_trait::async_trait]
+impl FeedFilter for Merge {
+  async fn run(&self, feed: &mut Feed) -> Result<()> {
+    let mut new_feed = self.client.fetch_feed(&self.source).await?;
+    self.filters.process(&mut new_feed).await?;
+    feed.merge(new_feed)?;
+    Ok(())
+  }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -45,6 +45,9 @@ pub enum Error {
   #[error("Feed parsing error {0:?}")]
   FeedParse(&'static str),
 
+  #[error("Feed merge error {0:?}")]
+  FeedMerge(&'static str),
+
   #[error("Reqwest client error {0:?}")]
   Reqwest(#[from] reqwest::Error),
 


### PR DESCRIPTION
Implements #11.

The new filter's name is `merge_feed` and the config type is either:

- an string, which is interpreted as the url of the source to merge
- or a full config object with the following properties:
  - `source` (string, required): the source url of the extra feed
  - `client` (string, optional): any Client config
  - `filters` (string, optional): a list of filters to run on the extra feed before merging it

Here's an example config using the `merge_feed` filter:

``` yaml
endpoints:
  - path: "/my-feed"
    source: "https://example.com/feed"
    filters:
      - merge_feed: "https://example.com/extra-feed"

  - path: "/my-feed"
    source: "https://example.com/feed"
    filters:
      - merge_feed:
          source: "https://example.com/extra-feed"
          client:
            timeout: 10
          filters:
            - full_text: {}
            - js: |
              function modify_post(feed, post) {
                post.title += " (merged);
                return post;
              }
```