### PR TITLE
test: read from fixture directory

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -163,6 +163,11 @@ impl Client {
     url: &Url,
     f: impl FnOnce(reqwest::RequestBuilder) -> reqwest::RequestBuilder,
   ) -> Result<Response> {
+    #[cfg(test)]
+    if url.scheme() == "fixture" {
+      return Ok(Response::from_fixture(url));
+    }
+
     if let Some(resp) = self.cache.get_cached(url) {
       return Ok(resp);
     }
@@ -181,13 +186,6 @@ impl Client {
 
     resp.set_content_type(assume_content_type);
     resp
-  }
-
-  #[cfg(test)]
-  pub fn insert_fixture(&self, url: &str, content_type: &str, content: &str) {
-    let url = url::Url::parse(url).expect("invalid url");
-    let resp = Response::from_fixture(content_type, content);
-    self.insert(url, resp);
   }
 
   #[cfg(test)]

--- a/src/client/cache.rs
+++ b/src/client/cache.rs
@@ -105,18 +105,20 @@ impl Response {
 
     let path: PathBuf =
       format!("{}/fixtures/{}", env!("CARGO_MANIFEST_DIR"), url.path()).into();
+    let content_type = url
+      .query_pairs()
+      .find(|(k, _)| k == "content_type")
+      .map(|(_, v)| v.to_string())
+      .unwrap_or_else(|| "text/xml; charset=utf-8".into());
 
     if !path.exists() {
       panic!("fixture file does not exist: {}", path.display());
     }
 
-    let status = reqwest::StatusCode::OK;
     let mut headers = HeaderMap::new();
     headers.insert(
       "content-type",
-      "text/xml; charset=utf-8"
-        .parse()
-        .expect("invalid content-type"),
+      content_type.parse().expect("invalid content-type"),
     );
     let body = std::fs::read(path)
       .expect("failed to read fixture file")
@@ -125,7 +127,7 @@ impl Response {
     Self {
       inner: Arc::new(InnerResponse {
         url: url.clone(),
-        status,
+        status: reqwest::StatusCode::OK,
         headers,
         body,
       }),

--- a/src/filter/js.rs
+++ b/src/filter/js.rs
@@ -105,7 +105,7 @@ mod tests {
     let config = r#"
       !endpoint
       path: /feed.xml
-      source: http://fixture/scishow.xml
+      source: fixture:///scishow.xml
       filters:
         - js: |
             function modify_feed(feed) {

--- a/src/filter/merge.rs
+++ b/src/filter/merge.rs
@@ -98,10 +98,10 @@ mod test {
     let config = r#"
       !endpoint
       path: /feed.xml
-      source: https://www.youtube.com/feeds/videos.xml?channel_id=UCZYTClx2T1of7BRZ86-8fow
+      source: fixture:///scishow.xml
       filters:
         - merge:
-            source: https://www.youtube.com/feeds/videos.xml?channel_id=UCZYTClx2T1of7BRZ86-8fow
+            source: fixture:///scishow.xml
             filters:
               - js: |
                   function modify_post(feed, post) {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -86,22 +86,8 @@ pub async fn fetch_endpoint(config: &str, query: &str) -> Feed {
     .expect("failed to parse feed")
 }
 
-macro_rules! include_fixture {
-  ($name:literal) => {
-    include_str!(concat!("../fixtures/", $name))
-  };
-}
-
 fn dummy_client() -> Client {
-  let client = ClientConfig::default()
+  ClientConfig::default()
     .build(Duration::from_secs(10))
-    .expect("failed to build client");
-
-  client.insert_fixture(
-    "http://fixture/scishow.xml",
-    "text/xml; charset=UTF-8",
-    include_fixture!("scishow.xml"),
-  );
-
-  client
+    .expect("failed to build client")
 }


### PR DESCRIPTION
previous approach to read from fixture by inserting fixture files into the cache of the client was not working for two reasons:

- the dummy client is only constructed for the source client, which means other requests like the one used in `merge_feed` filter can't use the fixtures.
- the cache has its own purpose and should be considered orthogonal to the fixtures, as it's consider an internal logic of the client. It's not a good idea to rely on the cache for providing fixtures for testing.

This commit changes the approach to read from fixture files by requesting with `fixtures://` scheme, which is then handled by a custom adapter that reads the file from the fixture directory. Note, the `fixtures://` scheme is only handled in test environment.