### PR TITLE
fix bind adress in docker compose example

### DIFF
--- a/README.org
+++ b/README.org
@@ -25,7 +25,7 @@ services:
       - 4080:4080
     volumes:
       - ./funnel.yaml:/funnel.yaml
-    command: /rss-funnel -c /funnel.yaml server
+    command: /rss-funnel -c /funnel.yaml server -b 0.0.0.0:4080
 #+end_src
 
 Alternatively, you can build it directly from source:


### PR DESCRIPTION
By default app listen on 127.0.0.1:4080 which is unreachable outside container, even with exposed port

Closes #4