### PR TITLE
feat(inspector-ui): add a reload button

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,9 +160,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "202651474fe73c62d9e0a56c6133f7a0ff1dc1c8cf7a5b03381af2a26553ac9d"
+checksum = "1236b4b292f6c4d6dc34604bb5120d85c3fe1d1aa596bd5cc52ca054d13e7b9e"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -171,7 +171,7 @@ dependencies = [
  "http 1.0.0",
  "http-body 1.0.0",
  "http-body-util",
- "hyper 1.0.1",
+ "hyper 1.1.0",
  "hyper-util",
  "itoa 1.0.10",
  "matchit",
@@ -189,13 +189,14 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
 name = "axum-core"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77cb22c689c44d4c07b0ab44ebc25d69d8ae601a2f28fb8d672d344178fa17aa"
+checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -209,6 +210,7 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1051,9 +1053,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f9214f3e703236b221f1a9cd88ec8b4adfa5296de01ab96216361f4692f56"
+checksum = "fb5aa53871fc917b1a9ed87b683a5d86db645e23acb32c2e0785a353e522fb75"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1084,22 +1086,18 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca339002caeb0d159cc6e023dff48e199f081e42fa039895c7c6f38b37f2e9d"
+checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
 dependencies = [
  "bytes",
- "futures-channel",
  "futures-util",
  "http 1.0.0",
  "http-body 1.0.0",
- "hyper 1.0.1",
+ "hyper 1.1.0",
  "pin-project-lite",
  "socket2",
  "tokio",
- "tower",
- "tower-service",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ serde_regex = "1.1.0"
 
 # webserver
 axum-macros = "0.4.1"
-axum = { version = "0.7.2", features = ["json"] }
+axum = { version = "0.7.4", features = ["json"] }
 tower = "0.4.13"
 
 # Feed formats support

--- a/inspector/src/FeedInspector.js
+++ b/inspector/src/FeedInspector.js
@@ -37,19 +37,25 @@ export class FeedInspector {
       return;
     }
 
-    let endpoint_still_exists = this.config.endpoints.find((endpoint) => {
-      return endpoint.path === this.current_endpoint?.path;
-    });
-
-    if (!endpoint_still_exists) {
-      this.current_endpoint = null;
+    if (!this.current_endpoint) {
       await this.load_endpoints();
       await this.reset_main_ui();
-    } else {
-      this.update_request_param_controls();
-      this.render_filters();
-      this.fetch_and_render_feed();
     }
+
+    for (const endpoint of this.config.endpoints) {
+      if (this.current_endpoint?.path === endpoint.path) {
+        this.current_endpoint = endpoint;
+        this.update_request_param_controls();
+        this.render_filters();
+        this.fetch_and_render_feed();
+        return;
+      }
+    }
+
+    // current endpoint was deleted, reset everything
+    this.current_endpoint = null;
+    await this.load_endpoints();
+    await this.reset_main_ui();
   }
 
   async setup_reload_config_handler() {

--- a/inspector/src/index.html
+++ b/inspector/src/index.html
@@ -13,6 +13,7 @@
   <body>
     <div class="container">
       <div id="sidebar-panel">
+        <div class="button" id="reload-config-button">Reload Config</div>
         <div id="sidebar-endpoints">
           <div class="sidebar-header">
             <h4>Endpoints</h4>

--- a/inspector/src/style.css
+++ b/inspector/src/style.css
@@ -34,7 +34,8 @@ body {
 }
 
 #sidebar-panel {
-  > div {
+  #sidebar-endpoints,
+  #main-panel {
     display: flex;
     flex-direction: column;
     height: 100%;
@@ -51,6 +52,11 @@ body {
     margin: 0.5rem 0;
     padding-bottom: 0.5rem;
   }
+}
+
+#reload-config-button {
+  text-align: center;
+  margin-bottom: 0.5rem;
 }
 
 .button {

--- a/src/server.rs
+++ b/src/server.rs
@@ -5,6 +5,7 @@ use std::{path::Path, sync::Arc, time::Duration};
 
 use axum::{routing::get, Router};
 use clap::Parser;
+use futures::{future, Future};
 use http::StatusCode;
 use tokio::sync::mpsc;
 use tower_http::compression::CompressionLayer;
@@ -50,7 +51,7 @@ impl ServerConfig {
   #[allow(unused)]
   pub async fn run_without_fs_watcher(self, config_path: &Path) -> Result<()> {
     let config = FeedDefinition::load_from_file(config_path)?;
-    self.serve(config).await
+    self.serve(config, future::pending()).await
   }
 
   pub async fn run_with_fs_watcher(self, config_path: &Path) -> Result<()> {
@@ -62,21 +63,36 @@ impl ServerConfig {
           .into(),
       );
     };
-    let mut task_handle = tokio::task::spawn(self.clone().serve(config));
+    let (mut tx, mut rx) = mpsc::channel(1);
+
+    let mut task_handle = tokio::task::spawn(
+      self
+        .clone()
+        .serve(config, async move { rx.recv().await.unwrap() }),
+    );
     let mut config_update = debounce(Duration::from_millis(500), config_update);
 
     while let Some(new_config) = config_update.recv().await {
       info!("config updated, restarting server");
-      task_handle.abort();
+      tx.send(()).await.ok();
       task_handle.await.ok();
 
-      task_handle = tokio::task::spawn(self.clone().serve(new_config));
+      (tx, rx) = mpsc::channel(1);
+      task_handle = tokio::task::spawn(
+        self
+          .clone()
+          .serve(new_config, async move { rx.recv().await.unwrap() }),
+      );
     }
 
     Ok(())
   }
 
-  pub async fn serve(self, feed_definition: FeedDefinition) -> Result<()> {
+  pub async fn serve(
+    self,
+    feed_definition: FeedDefinition,
+    shutdown_signal: impl Future<Output = ()> + Send + 'static,
+  ) -> Result<()> {
     info!("listening on {}", &self.bind);
     let listener = tokio::net::TcpListener::bind(&*self.bind).await?;
 
@@ -103,6 +119,7 @@ impl ServerConfig {
 
     info!("starting server");
     let server = axum::serve(listener, app);
+    let server = server.with_graceful_shutdown(shutdown_signal);
 
     Ok(server.await?)
   }

--- a/src/server.rs
+++ b/src/server.rs
@@ -151,7 +151,6 @@ async fn fs_watcher(
     }
     Ok(_) => {}
     Err(_) => {
-      dbg!(&event);
       error!("file watcher error: {:?}", event);
     }
   };


### PR DESCRIPTION
Add a reload button that reloads the config manually.

In the future I may implement this to be automatic, probably with a websocket connection to the backend to detect reload events. For the time being, I think this button is a simple and good enough solution.

In the passing I found a bug with the response in `_inspector/config` is not being updated when the config is reloaded. I fixed that as well.