### PR TITLE
feat: create feed from scratch

### DIFF
--- a/inspector/src/FeedInspector.js
+++ b/inspector/src/FeedInspector.js
@@ -47,6 +47,7 @@ export class FeedInspector {
         this.current_endpoint = endpoint;
         this.update_request_param_controls();
         this.render_filters();
+        this.render_feed_source();
         this.fetch_and_render_feed();
         return;
       }
@@ -118,7 +119,7 @@ export class FeedInspector {
   }
 
   async load_endpoints() {
-    $("#sidebar-filters").classList.add("hidden");
+    $("#sidebar-endpoint").classList.add("hidden");
     $("#sidebar-endpoints").classList.remove("hidden");
     $("#endpoint-list").innerHTML = "";
 
@@ -273,7 +274,10 @@ export class FeedInspector {
     $("#copy-endpoint-url").addEventListener("click", () => {
       this.copy_endpoint_url(this.current_endpoint);
     });
-    $("#sidebar-filters").classList.remove("hidden");
+    $("#sidebar-endpoint").classList.remove("hidden");
+
+    // show feed source
+    this.render_feed_source();
 
     // show filter list
     this.render_filters();
@@ -285,6 +289,57 @@ export class FeedInspector {
     // show feed preview
     await this.fetch_feed();
     this.render_feed();
+  }
+
+  async render_feed_source() {
+    if (!this.current_endpoint) return;
+    const { source } = this.current_endpoint;
+    const header = $("#source-info > header");
+    const content = $("#source-info > content");
+
+    content.innerHTML = "";
+
+    if (!source) {
+      header.innerText = "Dynamic source";
+      content.innerHTML =
+        "Please specify it in the <code>source</code> parameter.";
+      return;
+    }
+
+    // if source is a string, then render it as an <a>
+    if (typeof source === "string") {
+      header.innerText = "Source";
+      content.appendChild(
+        elt(
+          "a",
+          { class: "feed-link", href: source, target: "_blank" },
+          source,
+        ),
+      );
+      return;
+    }
+
+    // if source is an object with a format field, indicate the source is a blank feed
+    // with specified title, link, and description field.
+    if (source.format) {
+      header.innerText = "Feed from scratch";
+      const table = elt("table", { class: "scratch-feed" }, [
+        elt("tr", { class: "feed-property" }, [
+          elt("th", {}, "Title"),
+          elt("td", {}, source.title),
+        ]),
+        elt("tr", { class: "feed-property" }, [
+          elt("th", {}, "Link"),
+          elt("td", {}, source.link),
+        ]),
+        elt("tr", { class: "feed-property" }, [
+          elt("th", {}, "Description"),
+          elt("td", {}, source.description),
+        ]),
+      ]);
+      content.appendChild(table);
+      return;
+    }
   }
 
   async fetch_feed() {

--- a/inspector/src/FeedInspector.js
+++ b/inspector/src/FeedInspector.js
@@ -246,13 +246,20 @@ export class FeedInspector {
     const { source, filters } = this.current_endpoint;
 
     // switch main ui
-    $("input#source", $("#request-param")).disabled = !!source;
-    if (source) {
-      $("input#source", $("#request-param")).placeholder = source;
-      $("input#source", $("#request-param")).value = "";
+    $("#request-param input#source").disabled = !!source;
+    if (!source) {
+      $("#request-param input#source").value = "";
+      $("#request-param input#source").placeholder =
+        "Please specify the feed source here.";
+      $("#request-param input#source").readOnly = false;
+    } else if (typeof source === "string") {
+      $("#request-param input#source").value = source;
+      $("#request-param input#source").readOnly = true;
     } else {
-      $("input#source", $("#request-param")).placeholder =
-        "Source not configured. Please specify it here.";
+      $("#request-param input#source").value = "";
+      $("#request-param input#source").placeholder =
+        "The source is a feed from scratch";
+      $("#request-param input#source").readOnly = true;
     }
 
     // update parameter input

--- a/inspector/src/index.html
+++ b/inspector/src/index.html
@@ -18,15 +18,27 @@
           <div class="sidebar-header">
             <h4>Endpoints</h4>
           </div>
-          <ul id="endpoint-list" class="sidebar-body"></ul>
+          <ul id="endpoint-list"></ul>
         </div>
-        <div id="sidebar-filters" class="hidden">
+
+        <div id="sidebar-endpoint" class="hidden">
           <div class="sidebar-header">
             <div class="button" id="back-to-endpoints">Back</div>
             <span id="endpoint-name"></span>
             <div class="button" id="copy-endpoint-url">Copy URL</div>
           </div>
-          <ul id="filter-list" class="sidebar-body"></ul>
+          <div class="sidebar-content">
+            <div id="source-info" class="info-box">
+              <header></header>
+              <content></content>
+            </div>
+            <div id="filter-info" class="info-box">
+              <header>Filters</header>
+              <content>
+                <ul id="filter-list"></ul>
+              </content>
+            </div>
+          </div>
         </div>
       </div>
       <div id="main-panel" class="hidden">

--- a/inspector/src/index.html
+++ b/inspector/src/index.html
@@ -45,11 +45,7 @@
         <div id="request-param">
           <label for="source"
             >Source
-            <input
-              type="text"
-              placeholder="http://your-source/feed.xml"
-              id="source"
-            />
+            <input type="text" placeholder="Source" id="source" />
           </label>
 
           <label for="limit-posts"

--- a/inspector/src/style.css
+++ b/inspector/src/style.css
@@ -6,13 +6,17 @@ body {
   margin: 0;
 }
 
+table th {
+  text-align: right;
+  vertical-align: top;
+}
+
 .hidden {
   display: none !important;
 }
 
 .container {
   display: flex;
-  overflow: hidden;
   flex-direction: row;
   position: absolute;
   padding: 10px;
@@ -34,8 +38,12 @@ body {
 }
 
 #sidebar-panel {
+  display: flex;
+  flex-direction: column;
+
   #sidebar-endpoints,
-  #main-panel {
+  #main-panel,
+  #sidebar-endpoint {
     display: flex;
     flex-direction: column;
     height: 100%;
@@ -43,7 +51,6 @@ body {
 
   .sidebar-body {
     overflow-x: hidden;
-    overflow-y: auto;
     margin-top: 0;
     margin-bottom: 0;
   }
@@ -71,7 +78,26 @@ body {
   }
 }
 
-#sidebar-filters {
+.info-box {
+  padding: 0.5rem 0.5rem;
+  border: 1px solid #ddd;
+  border-radius: 0.3rem;
+
+  > header {
+    background-color: white;
+    width: fit-content;
+    padding: 0 0.3rem;
+    position: relative;
+    /* half (padding-y + border) + half font height */
+    margin-top: -1rem;
+    font-size: 0.8em;
+  }
+
+  > content {
+  }
+}
+
+#sidebar-endpoint {
   .sidebar-header {
     display: flex;
     align-items: center;
@@ -90,6 +116,33 @@ body {
       font-size: 1.2em;
     }
   }
+
+  .sidebar-content {
+    flex-grow: 1;
+    overflow-y: scroll;
+  }
+
+  #filter-info {
+  }
+
+  #source-info {
+    margin: 1rem 0;
+
+    content {
+      position: relative;
+
+      .format-tag {
+        position: absolute;
+        right: 0;
+        top: 0;
+        background-color: #f60;
+        padding: 0.2rem 0.5rem;
+        color: #fff;
+        border-radius: 0.5rem;
+        font-size: 0.8em;
+      }
+    }
+  }
 }
 
 #fetch-status {
@@ -98,17 +151,16 @@ body {
 }
 
 ul#filter-list {
+  margin: 0.3rem 0;
   list-style: none;
   padding-left: 0;
   display: flex;
   flex-direction: column;
   gap: 0.3rem;
-  overflow: scroll;
 
   .filter {
     background-color: #fafafa;
     padding: 0.4rem 0.6rem 0.6rem 0.6rem;
-    border: 1px dotted #ddd;
     border-radius: 0.3rem;
     width: 100%;
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -49,7 +49,7 @@ struct TestConfig {
 impl TestConfig {
   fn to_endpoint_param(&self) -> server::EndpointParam {
     server::EndpointParam::new(
-      self.source.as_ref().cloned().map(|x| x.into()),
+      self.source.as_ref().cloned(),
       self.limit_filters,
       self.limit_posts,
       !self.compact_output,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -49,7 +49,7 @@ struct TestConfig {
 impl TestConfig {
   fn to_endpoint_param(&self) -> server::EndpointParam {
     server::EndpointParam::new(
-      self.source.clone(),
+      self.source.as_ref().cloned().map(|x| x.into()),
       self.limit_filters,
       self.limit_posts,
       !self.compact_output,

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -17,7 +17,23 @@ pub enum Feed {
   Atom(atom_syndication::Feed),
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum FeedFormat {
+  Rss,
+  Atom,
+}
+
 impl Feed {
+  // currently only used in tests.
+  #[cfg(test)]
+  pub fn format(&self) -> FeedFormat {
+    match self {
+      Feed::Rss(_) => FeedFormat::Rss,
+      Feed::Atom(_) => FeedFormat::Atom,
+    }
+  }
+
   pub fn from_rss_content(content: &str) -> Result<Self> {
     let cursor = std::io::Cursor::new(content);
     let channel = rss::Channel::read_from(cursor)?;
@@ -130,7 +146,7 @@ impl Feed {
 
 impl From<&BlankFeed> for Feed {
   fn from(config: &BlankFeed) -> Self {
-    use crate::source::FeedFormat::*;
+    use FeedFormat::*;
     match config.format {
       Rss => {
         let mut channel = rss::Channel {

--- a/src/filter/merge.rs
+++ b/src/filter/merge.rs
@@ -81,7 +81,7 @@ pub struct Merge {
 #[async_trait::async_trait]
 impl FeedFilter for Merge {
   async fn run(&self, feed: &mut Feed) -> Result<()> {
-    let mut new_feed = self.source.fetch_feed(None, Some(&self.client)).await?;
+    let mut new_feed = self.source.fetch_feed(Some(&self.client), None).await?;
     self.filters.process(&mut new_feed).await?;
     feed.merge(new_feed)?;
     Ok(())

--- a/src/filter/merge.rs
+++ b/src/filter/merge.rs
@@ -1,10 +1,10 @@
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
-use url::Url;
 
 use crate::client::{Client, ClientConfig};
 use crate::feed::Feed;
+use crate::source::{Source, SourceConfig};
 use crate::util::Result;
 
 use super::{FeedFilter, FeedFilterConfig, FilterConfig, Filters};
@@ -19,12 +19,12 @@ pub enum MergeConfig {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(transparent)]
 pub struct MergeSimpleConfig {
-  source: String,
+  source: SourceConfig,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct MergeFullConfig {
-  source: String,
+  source: SourceConfig,
   #[serde(default)]
   client: ClientConfig,
   #[serde(default)]
@@ -62,7 +62,7 @@ impl FeedFilterConfig for MergeConfig {
     } = self.into();
     let client = client.build(Duration::from_secs(15 * 60))?;
     let filters = Filters::from_config(filters).await?;
-    let source = Url::parse(&source)?;
+    let source = source.try_into()?;
 
     Ok(Merge {
       client,
@@ -74,14 +74,14 @@ impl FeedFilterConfig for MergeConfig {
 
 pub struct Merge {
   client: Client,
-  source: Url,
+  source: Source,
   filters: Filters,
 }
 
 #[async_trait::async_trait]
 impl FeedFilter for Merge {
   async fn run(&self, feed: &mut Feed) -> Result<()> {
-    let mut new_feed = self.client.fetch_feed(&self.source).await?;
+    let mut new_feed = self.source.fetch_feed(None, Some(&self.client)).await?;
     self.filters.process(&mut new_feed).await?;
     feed.merge(new_feed)?;
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod filter;
 mod html;
 mod js;
 mod server;
+mod source;
 #[cfg(test)]
 mod test_utils;
 mod util;

--- a/src/server/endpoint.rs
+++ b/src/server/endpoint.rs
@@ -5,10 +5,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use axum::body::Body;
-use axum::extract::FromRequestParts;
 use axum::response::IntoResponse;
-use http::request::Parts;
-use http::{StatusCode, Uri};
+use http::StatusCode;
 use mime::Mime;
 use serde::{Deserialize, Serialize};
 use tower::Service;

--- a/src/source.rs
+++ b/src/source.rs
@@ -15,6 +15,7 @@ pub enum SourceConfig {
   FromScratch(BlankFeed),
 }
 
+#[derive(Clone, Debug)]
 pub enum Source {
   AbsoluteUrl(Url),
   RelativeUrl(String),
@@ -34,6 +35,12 @@ pub struct BlankFeed {
   pub title: String,
   pub link: Option<String>,
   pub description: Option<String>,
+}
+
+impl From<Url> for Source {
+  fn from(url: Url) -> Self {
+    Source::AbsoluteUrl(url)
+  }
 }
 
 impl TryFrom<SourceConfig> for Source {
@@ -56,8 +63,8 @@ impl TryFrom<SourceConfig> for Source {
 impl Source {
   pub async fn fetch_feed(
     &self,
-    request: Option<&Parts>,
     client: Option<&Client>,
+    request: Option<&Parts>,
   ) -> Result<Feed> {
     if let Source::FromScratch(config) = self {
       let feed = Feed::from(config);

--- a/src/source.rs
+++ b/src/source.rs
@@ -1,0 +1,82 @@
+use axum::extract::Request;
+use serde::Deserialize;
+use url::Url;
+
+use crate::{
+  client::Client,
+  feed::Feed,
+  util::{ConfigError, Error, Result},
+};
+
+#[derive(Deserialize, Clone, Debug)]
+#[serde(untagged)]
+enum SourceConfig {
+  Simple(String),
+  FromScratch(BlankFeed),
+}
+
+enum Source {
+  AbsoluteUrl(Url),
+  RelativeUrl(String),
+  FromScratch(BlankFeed),
+}
+
+#[derive(Deserialize, Clone, Debug)]
+#[serde(rename_all = "lowercase")]
+pub enum FeedFormat {
+  Rss,
+  Atom,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct BlankFeed {
+  pub format: FeedFormat,
+  pub title: String,
+  pub link: Option<String>,
+  pub description: Option<String>,
+}
+
+impl TryFrom<SourceConfig> for Source {
+  type Error = ConfigError;
+
+  fn try_from(config: SourceConfig) -> Result<Self, Self::Error> {
+    match config {
+      SourceConfig::Simple(url) if url.starts_with('/') => {
+        Ok(Source::RelativeUrl(url))
+      }
+      SourceConfig::Simple(url) => {
+        let url = Url::parse(&url)?;
+        Ok(Source::AbsoluteUrl(url))
+      }
+      SourceConfig::FromScratch(config) => Ok(Source::FromScratch(config)),
+    }
+  }
+}
+
+impl Source {
+  pub async fn fetch_feed(
+    &self,
+    request: Option<&Request>,
+    client: Option<&Client>,
+  ) -> Result<Feed> {
+    if let Source::FromScratch(config) = self {
+      let feed = Feed::from(config);
+      return Ok(feed);
+    }
+
+    let client =
+      client.ok_or_else(|| Error::Message("client not set".into()))?;
+    let source_url = match self {
+      Source::AbsoluteUrl(url) => url.clone(),
+      Source::RelativeUrl(path) => {
+        let request =
+          request.ok_or_else(|| Error::Message("request not set".into()))?;
+        let this_url: Url = request.uri().to_string().parse()?;
+        this_url.join(path)?
+      }
+      Source::FromScratch(_) => unreachable!(),
+    };
+
+    client.fetch_feed(&source_url).await
+  }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -18,6 +18,9 @@ pub enum ConfigError {
   #[error("Regex error")]
   Regex(#[from] regex::Error),
 
+  #[error("Invalid URL {0}")]
+  InvalidUrl(#[from] url::ParseError),
+
   #[error("{0}")]
   Message(String),
 }


### PR DESCRIPTION
Fixes #35.

Now it's possible to specify in the `source` field (under `endpoint`, or in `merge` filter's config) a struct that looks like this:

``` yaml
- path: /feed.xml
  source:
    format: rss # or atom
    title: "My Feed"
    description: "This is my feed"
    link: "https://example.com/"
```

Don't forget to ensure the inspector ui has proper support for it before merging.