### PR TITLE
refactor: FeedFilter trait

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -34,7 +34,7 @@ impl FilterContext {
 
 #[async_trait::async_trait]
 pub trait FeedFilter {
-  async fn run(&self, ctx: &mut FilterContext, feed: &mut Feed) -> Result<()>;
+  async fn run(&self, ctx: &mut FilterContext, feed: Feed) -> Result<Feed>;
 }
 
 #[async_trait::async_trait]
@@ -49,7 +49,7 @@ pub struct BoxedFilter(Arc<dyn FeedFilter + Send + Sync>);
 
 #[async_trait::async_trait]
 impl FeedFilter for BoxedFilter {
-  async fn run(&self, ctx: &mut FilterContext, feed: &mut Feed) -> Result<()> {
+  async fn run(&self, ctx: &mut FilterContext, feed: Feed) -> Result<Feed> {
     self.0.run(ctx, feed).await
   }
 }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -23,7 +23,7 @@ impl FilterContext {
 
 #[async_trait::async_trait]
 pub trait FeedFilter {
-  async fn run(&self, ctx: &FilterContext, feed: &mut Feed) -> Result<()>;
+  async fn run(&self, ctx: &mut FilterContext, feed: &mut Feed) -> Result<()>;
 }
 
 #[async_trait::async_trait]
@@ -38,7 +38,7 @@ pub struct BoxedFilter(Arc<dyn FeedFilter + Send + Sync>);
 
 #[async_trait::async_trait]
 impl FeedFilter for BoxedFilter {
-  async fn run(&self, ctx: &FilterContext, feed: &mut Feed) -> Result<()> {
+  async fn run(&self, ctx: &mut FilterContext, feed: &mut Feed) -> Result<()> {
     self.0.run(ctx, feed).await
   }
 }
@@ -68,7 +68,7 @@ impl Filters {
 
   pub async fn process(
     &self,
-    ctx: &FilterContext,
+    ctx: &mut FilterContext,
     feed: &mut Feed,
   ) -> Result<()> {
     self.process_partial(feed, ctx, self.filters.len()).await
@@ -77,7 +77,7 @@ impl Filters {
   pub async fn process_partial(
     &self,
     feed: &mut Feed,
-    ctx: &FilterContext,
+    ctx: &mut FilterContext,
     limit_filters: usize,
   ) -> Result<()> {
     for filter in self.filters.iter().take(limit_filters) {

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -24,6 +24,12 @@ impl FilterContext {
       limit_filters: None,
     }
   }
+
+  pub fn subcontext(&self) -> Self {
+    Self {
+      limit_filters: None,
+    }
+  }
 }
 
 #[async_trait::async_trait]

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -52,41 +52,6 @@ impl BoxedFilter {
   }
 }
 
-pub struct Filters {
-  filters: Vec<BoxedFilter>,
-}
-
-impl Filters {
-  pub async fn from_config(filter_configs: Vec<FilterConfig>) -> Result<Self> {
-    let mut filters = Vec::new();
-    for filter_config in filter_configs {
-      let filter = filter_config.build().await?;
-      filters.push(filter);
-    }
-    Ok(Self { filters })
-  }
-
-  pub async fn process(
-    &self,
-    ctx: &mut FilterContext,
-    feed: &mut Feed,
-  ) -> Result<()> {
-    self.process_partial(feed, ctx, self.filters.len()).await
-  }
-
-  pub async fn process_partial(
-    &self,
-    feed: &mut Feed,
-    ctx: &mut FilterContext,
-    limit_filters: usize,
-  ) -> Result<()> {
-    for filter in self.filters.iter().take(limit_filters) {
-      filter.run(ctx, feed).await?;
-    }
-    Ok(())
-  }
-}
-
 macro_rules! define_filters {
   ($($variant:ident => $config:ty);* ;) => {
     #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -13,11 +13,16 @@ use serde::{Deserialize, Serialize};
 
 use crate::{feed::Feed, util::Result};
 
-pub struct FilterContext {}
+#[derive(Clone)]
+pub struct FilterContext {
+  pub(crate) limit_filters: Option<usize>,
+}
 
 impl FilterContext {
   pub fn new() -> Self {
-    Self {}
+    Self {
+      limit_filters: None,
+    }
   }
 }
 

--- a/src/filter/full_text.rs
+++ b/src/filter/full_text.rs
@@ -154,7 +154,7 @@ impl FullTextFilter {
 
 #[async_trait::async_trait]
 impl FeedFilter for FullTextFilter {
-  async fn run(&self, _ctx: &FilterContext, feed: &mut Feed) -> Result<()> {
+  async fn run(&self, _ctx: &mut FilterContext, feed: &mut Feed) -> Result<()> {
     let posts = feed.take_posts();
     let posts = self.fetch_all_posts(posts).await?;
     feed.set_posts(posts);

--- a/src/filter/full_text.rs
+++ b/src/filter/full_text.rs
@@ -11,7 +11,7 @@ use crate::html::convert_relative_url;
 use crate::util::{Error, Result};
 
 use super::html::{KeepElement, KeepElementConfig};
-use super::{FeedFilter, FeedFilterConfig};
+use super::{FeedFilter, FeedFilterConfig, FilterContext};
 
 const DEFAULT_PARALLELISM: usize = 20;
 
@@ -154,7 +154,7 @@ impl FullTextFilter {
 
 #[async_trait::async_trait]
 impl FeedFilter for FullTextFilter {
-  async fn run(&self, feed: &mut Feed) -> Result<()> {
+  async fn run(&self, _ctx: &FilterContext, feed: &mut Feed) -> Result<()> {
     let posts = feed.take_posts();
     let posts = self.fetch_all_posts(posts).await?;
     feed.set_posts(posts);

--- a/src/filter/full_text.rs
+++ b/src/filter/full_text.rs
@@ -154,10 +154,14 @@ impl FullTextFilter {
 
 #[async_trait::async_trait]
 impl FeedFilter for FullTextFilter {
-  async fn run(&self, _ctx: &mut FilterContext, feed: &mut Feed) -> Result<()> {
+  async fn run(
+    &self,
+    _ctx: &mut FilterContext,
+    mut feed: Feed,
+  ) -> Result<Feed> {
     let posts = feed.take_posts();
     let posts = self.fetch_all_posts(posts).await?;
     feed.set_posts(posts);
-    Ok(())
+    Ok(feed)
   }
 }

--- a/src/filter/highlight.rs
+++ b/src/filter/highlight.rs
@@ -1,4 +1,4 @@
-use super::{FeedFilter, FeedFilterConfig};
+use super::{FeedFilter, FeedFilterConfig, FilterContext};
 use ego_tree::{NodeId, NodeMut};
 use regex::{Regex, RegexBuilder, RegexSet, RegexSetBuilder};
 use scraper::{Html, Node};
@@ -209,7 +209,11 @@ impl Highlight {
 
 #[async_trait::async_trait]
 impl FeedFilter for Highlight {
-  async fn run(&self, feed: &mut crate::feed::Feed) -> Result<()> {
+  async fn run(
+    &self,
+    _ctx: &FilterContext,
+    feed: &mut crate::feed::Feed,
+  ) -> Result<()> {
     let mut posts = feed.take_posts();
 
     for post in &mut posts {

--- a/src/filter/highlight.rs
+++ b/src/filter/highlight.rs
@@ -211,7 +211,7 @@ impl Highlight {
 impl FeedFilter for Highlight {
   async fn run(
     &self,
-    _ctx: &FilterContext,
+    _ctx: &mut FilterContext,
     feed: &mut crate::feed::Feed,
   ) -> Result<()> {
     let mut posts = feed.take_posts();

--- a/src/filter/highlight.rs
+++ b/src/filter/highlight.rs
@@ -5,6 +5,7 @@ use scraper::{Html, Node};
 use serde::{Deserialize, Serialize};
 
 use crate::{
+  feed::Feed,
   html::fragment_root_node_id,
   util::{ConfigError, Result},
 };
@@ -212,8 +213,8 @@ impl FeedFilter for Highlight {
   async fn run(
     &self,
     _ctx: &mut FilterContext,
-    feed: &mut crate::feed::Feed,
-  ) -> Result<()> {
+    mut feed: Feed,
+  ) -> Result<Feed> {
     let mut posts = feed.take_posts();
 
     for post in &mut posts {
@@ -224,7 +225,7 @@ impl FeedFilter for Highlight {
 
     feed.set_posts(posts);
 
-    Ok(())
+    Ok(feed)
   }
 }
 

--- a/src/filter/html.rs
+++ b/src/filter/html.rs
@@ -84,7 +84,7 @@ impl RemoveElement {
 
 #[async_trait::async_trait]
 impl FeedFilter for RemoveElement {
-  async fn run(&self, _ctx: &FilterContext, feed: &mut Feed) -> Result<()> {
+  async fn run(&self, _ctx: &mut FilterContext, feed: &mut Feed) -> Result<()> {
     let mut posts = feed.take_posts();
 
     for post in &mut posts {
@@ -171,7 +171,7 @@ impl KeepElement {
 
 #[async_trait::async_trait]
 impl FeedFilter for KeepElement {
-  async fn run(&self, _ctx: &FilterContext, feed: &mut Feed) -> Result<()> {
+  async fn run(&self, _ctx: &mut FilterContext, feed: &mut Feed) -> Result<()> {
     let mut posts = feed.take_posts();
 
     for post in &mut posts {
@@ -390,7 +390,7 @@ fn transpose_option_vec<T: Clone>(
 
 #[async_trait::async_trait]
 impl FeedFilter for Split {
-  async fn run(&self, _ctx: &FilterContext, feed: &mut Feed) -> Result<()> {
+  async fn run(&self, _ctx: &mut FilterContext, feed: &mut Feed) -> Result<()> {
     let mut posts = vec![];
     for post in &feed.take_posts() {
       let mut split_posts = self.split(post)?;

--- a/src/filter/html.rs
+++ b/src/filter/html.rs
@@ -14,7 +14,7 @@ use crate::feed::Post;
 use crate::util::{Error, Result};
 use crate::{feed::Feed, util::ConfigError};
 
-use super::{FeedFilter, FeedFilterConfig};
+use super::{FeedFilter, FeedFilterConfig, FilterContext};
 
 /// Remove elements from HTML description.
 ///
@@ -84,7 +84,7 @@ impl RemoveElement {
 
 #[async_trait::async_trait]
 impl FeedFilter for RemoveElement {
-  async fn run(&self, feed: &mut Feed) -> Result<()> {
+  async fn run(&self, _ctx: &FilterContext, feed: &mut Feed) -> Result<()> {
     let mut posts = feed.take_posts();
 
     for post in &mut posts {
@@ -171,7 +171,7 @@ impl KeepElement {
 
 #[async_trait::async_trait]
 impl FeedFilter for KeepElement {
-  async fn run(&self, feed: &mut Feed) -> Result<()> {
+  async fn run(&self, _ctx: &FilterContext, feed: &mut Feed) -> Result<()> {
     let mut posts = feed.take_posts();
 
     for post in &mut posts {
@@ -390,7 +390,7 @@ fn transpose_option_vec<T: Clone>(
 
 #[async_trait::async_trait]
 impl FeedFilter for Split {
-  async fn run(&self, feed: &mut Feed) -> Result<()> {
+  async fn run(&self, _ctx: &FilterContext, feed: &mut Feed) -> Result<()> {
     let mut posts = vec![];
     for post in &feed.take_posts() {
       let mut split_posts = self.split(post)?;

--- a/src/filter/html.rs
+++ b/src/filter/html.rs
@@ -84,7 +84,11 @@ impl RemoveElement {
 
 #[async_trait::async_trait]
 impl FeedFilter for RemoveElement {
-  async fn run(&self, _ctx: &mut FilterContext, feed: &mut Feed) -> Result<()> {
+  async fn run(
+    &self,
+    _ctx: &mut FilterContext,
+    mut feed: Feed,
+  ) -> Result<Feed> {
     let mut posts = feed.take_posts();
 
     for post in &mut posts {
@@ -95,7 +99,7 @@ impl FeedFilter for RemoveElement {
     }
 
     feed.set_posts(posts);
-    Ok(())
+    Ok(feed)
   }
 }
 
@@ -171,7 +175,11 @@ impl KeepElement {
 
 #[async_trait::async_trait]
 impl FeedFilter for KeepElement {
-  async fn run(&self, _ctx: &mut FilterContext, feed: &mut Feed) -> Result<()> {
+  async fn run(
+    &self,
+    _ctx: &mut FilterContext,
+    mut feed: Feed,
+  ) -> Result<Feed> {
     let mut posts = feed.take_posts();
 
     for post in &mut posts {
@@ -182,7 +190,7 @@ impl FeedFilter for KeepElement {
     }
 
     feed.set_posts(posts);
-    Ok(())
+    Ok(feed)
   }
 }
 
@@ -390,7 +398,11 @@ fn transpose_option_vec<T: Clone>(
 
 #[async_trait::async_trait]
 impl FeedFilter for Split {
-  async fn run(&self, _ctx: &mut FilterContext, feed: &mut Feed) -> Result<()> {
+  async fn run(
+    &self,
+    _ctx: &mut FilterContext,
+    mut feed: Feed,
+  ) -> Result<Feed> {
     let mut posts = vec![];
     for post in &feed.take_posts() {
       let mut split_posts = self.split(post)?;
@@ -398,7 +410,7 @@ impl FeedFilter for Split {
     }
 
     feed.set_posts(posts);
-    Ok(())
+    Ok(feed)
   }
 }
 

--- a/src/filter/js.rs
+++ b/src/filter/js.rs
@@ -4,7 +4,7 @@ use crate::feed::Feed;
 use crate::js::{AsJson, Runtime};
 use crate::util::{Error, Result};
 
-use super::{FeedFilter, FeedFilterConfig};
+use super::{FeedFilter, FeedFilterConfig, FilterContext};
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(transparent)]
@@ -89,7 +89,7 @@ impl JsFilter {
 
 #[async_trait::async_trait]
 impl FeedFilter for JsFilter {
-  async fn run(&self, feed: &mut Feed) -> Result<()> {
+  async fn run(&self, _ctx: &FilterContext, feed: &mut Feed) -> Result<()> {
     self.modify_feed(feed).await?;
     self.modify_posts(feed).await?;
     Ok(())

--- a/src/filter/js.rs
+++ b/src/filter/js.rs
@@ -89,10 +89,14 @@ impl JsFilter {
 
 #[async_trait::async_trait]
 impl FeedFilter for JsFilter {
-  async fn run(&self, _ctx: &mut FilterContext, feed: &mut Feed) -> Result<()> {
-    self.modify_feed(feed).await?;
-    self.modify_posts(feed).await?;
-    Ok(())
+  async fn run(
+    &self,
+    _ctx: &mut FilterContext,
+    mut feed: Feed,
+  ) -> Result<Feed> {
+    self.modify_feed(&mut feed).await?;
+    self.modify_posts(&mut feed).await?;
+    Ok(feed)
   }
 }
 

--- a/src/filter/js.rs
+++ b/src/filter/js.rs
@@ -89,7 +89,7 @@ impl JsFilter {
 
 #[async_trait::async_trait]
 impl FeedFilter for JsFilter {
-  async fn run(&self, _ctx: &FilterContext, feed: &mut Feed) -> Result<()> {
+  async fn run(&self, _ctx: &mut FilterContext, feed: &mut Feed) -> Result<()> {
     self.modify_feed(feed).await?;
     self.modify_posts(feed).await?;
     Ok(())

--- a/src/filter/merge.rs
+++ b/src/filter/merge.rs
@@ -4,12 +4,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::client::{Client, ClientConfig};
 use crate::feed::Feed;
+use crate::filter_pipeline::{FilterPipeline, FilterPipelineConfig};
 use crate::source::{Source, SourceConfig};
 use crate::util::Result;
 
-use super::{
-  FeedFilter, FeedFilterConfig, FilterConfig, FilterContext, Filters,
-};
+use super::{FeedFilter, FeedFilterConfig, FilterContext};
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(untagged)]
@@ -30,7 +29,7 @@ pub struct MergeFullConfig {
   #[serde(default)]
   client: ClientConfig,
   #[serde(default)]
-  filters: Vec<FilterConfig>,
+  filters: FilterPipelineConfig,
 }
 
 impl From<MergeSimpleConfig> for MergeFullConfig {
@@ -63,7 +62,7 @@ impl FeedFilterConfig for MergeConfig {
       source,
     } = self.into();
     let client = client.build(Duration::from_secs(15 * 60))?;
-    let filters = Filters::from_config(filters).await?;
+    let filters = filters.build().await?;
     let source = source.try_into()?;
 
     Ok(Merge {
@@ -77,7 +76,7 @@ impl FeedFilterConfig for MergeConfig {
 pub struct Merge {
   client: Client,
   source: Source,
-  filters: Filters,
+  filters: FilterPipeline,
 }
 
 #[async_trait::async_trait]

--- a/src/filter/merge.rs
+++ b/src/filter/merge.rs
@@ -83,7 +83,7 @@ pub struct Merge {
 impl FeedFilter for Merge {
   async fn run(&self, ctx: &mut FilterContext, feed: &mut Feed) -> Result<()> {
     let new_feed = self.source.fetch_feed(Some(&self.client), None).await?;
-    let ctx = ctx.clone();
+    let ctx = ctx.subcontext();
     let filtered_new_feed = self.filters.run(ctx, new_feed).await?;
     feed.merge(filtered_new_feed)?;
     Ok(())

--- a/src/filter/merge.rs
+++ b/src/filter/merge.rs
@@ -82,9 +82,10 @@ pub struct Merge {
 #[async_trait::async_trait]
 impl FeedFilter for Merge {
   async fn run(&self, ctx: &mut FilterContext, feed: &mut Feed) -> Result<()> {
-    let mut new_feed = self.source.fetch_feed(Some(&self.client), None).await?;
-    self.filters.process(ctx, &mut new_feed).await?;
-    feed.merge(new_feed)?;
+    let new_feed = self.source.fetch_feed(Some(&self.client), None).await?;
+    let ctx = ctx.clone();
+    let filtered_new_feed = self.filters.run(ctx, new_feed).await?;
+    feed.merge(filtered_new_feed)?;
     Ok(())
   }
 }

--- a/src/filter/merge.rs
+++ b/src/filter/merge.rs
@@ -81,12 +81,12 @@ pub struct Merge {
 
 #[async_trait::async_trait]
 impl FeedFilter for Merge {
-  async fn run(&self, ctx: &mut FilterContext, feed: &mut Feed) -> Result<()> {
+  async fn run(&self, ctx: &mut FilterContext, mut feed: Feed) -> Result<Feed> {
     let new_feed = self.source.fetch_feed(Some(&self.client), None).await?;
     let ctx = ctx.subcontext();
     let filtered_new_feed = self.filters.run(ctx, new_feed).await?;
     feed.merge(filtered_new_feed)?;
-    Ok(())
+    Ok(feed)
   }
 }
 

--- a/src/filter/merge.rs
+++ b/src/filter/merge.rs
@@ -82,7 +82,7 @@ pub struct Merge {
 
 #[async_trait::async_trait]
 impl FeedFilter for Merge {
-  async fn run(&self, ctx: &FilterContext, feed: &mut Feed) -> Result<()> {
+  async fn run(&self, ctx: &mut FilterContext, feed: &mut Feed) -> Result<()> {
     let mut new_feed = self.source.fetch_feed(Some(&self.client), None).await?;
     self.filters.process(ctx, &mut new_feed).await?;
     feed.merge(new_feed)?;

--- a/src/filter/merge.rs
+++ b/src/filter/merge.rs
@@ -7,7 +7,9 @@ use crate::feed::Feed;
 use crate::source::{Source, SourceConfig};
 use crate::util::Result;
 
-use super::{FeedFilter, FeedFilterConfig, FilterConfig, Filters};
+use super::{
+  FeedFilter, FeedFilterConfig, FilterConfig, FilterContext, Filters,
+};
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(untagged)]
@@ -80,9 +82,9 @@ pub struct Merge {
 
 #[async_trait::async_trait]
 impl FeedFilter for Merge {
-  async fn run(&self, feed: &mut Feed) -> Result<()> {
+  async fn run(&self, ctx: &FilterContext, feed: &mut Feed) -> Result<()> {
     let mut new_feed = self.source.fetch_feed(Some(&self.client), None).await?;
-    self.filters.process(&mut new_feed).await?;
+    self.filters.process(ctx, &mut new_feed).await?;
     feed.merge(new_feed)?;
     Ok(())
   }

--- a/src/filter/sanitize.rs
+++ b/src/filter/sanitize.rs
@@ -118,7 +118,7 @@ impl Sanitize {
 
 #[async_trait::async_trait]
 impl FeedFilter for Sanitize {
-  async fn run(&self, _ctx: &FilterContext, feed: &mut Feed) -> Result<()> {
+  async fn run(&self, _ctx: &mut FilterContext, feed: &mut Feed) -> Result<()> {
     let mut posts = feed.take_posts();
     for post in &mut posts {
       if let Some(description) = post.description_mut() {

--- a/src/filter/sanitize.rs
+++ b/src/filter/sanitize.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::util::Result;
 use crate::{feed::Feed, util::ConfigError};
 
-use super::{FeedFilter, FeedFilterConfig};
+use super::{FeedFilter, FeedFilterConfig, FilterContext};
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 struct SanitizeOpReplaceConfig {
@@ -118,7 +118,7 @@ impl Sanitize {
 
 #[async_trait::async_trait]
 impl FeedFilter for Sanitize {
-  async fn run(&self, feed: &mut Feed) -> Result<()> {
+  async fn run(&self, _ctx: &FilterContext, feed: &mut Feed) -> Result<()> {
     let mut posts = feed.take_posts();
     for post in &mut posts {
       if let Some(description) = post.description_mut() {

--- a/src/filter/sanitize.rs
+++ b/src/filter/sanitize.rs
@@ -118,7 +118,11 @@ impl Sanitize {
 
 #[async_trait::async_trait]
 impl FeedFilter for Sanitize {
-  async fn run(&self, _ctx: &mut FilterContext, feed: &mut Feed) -> Result<()> {
+  async fn run(
+    &self,
+    _ctx: &mut FilterContext,
+    mut feed: Feed,
+  ) -> Result<Feed> {
     let mut posts = feed.take_posts();
     for post in &mut posts {
       if let Some(description) = post.description_mut() {
@@ -127,7 +131,7 @@ impl FeedFilter for Sanitize {
     }
 
     feed.set_posts(posts);
-    Ok(())
+    Ok(feed)
   }
 }
 

--- a/src/filter/select.rs
+++ b/src/filter/select.rs
@@ -1,7 +1,10 @@
 use regex::{Regex, RegexSet};
 use serde::{Deserialize, Serialize};
 
-use crate::util::{ConfigError, Result, SingleOrVec};
+use crate::{
+  feed::Feed,
+  util::{ConfigError, Result, SingleOrVec},
+};
 
 use super::{FeedFilter, FeedFilterConfig, FilterContext};
 
@@ -170,8 +173,8 @@ impl FeedFilter for Select {
   async fn run(
     &self,
     _ctx: &mut FilterContext,
-    feed: &mut crate::feed::Feed,
-  ) -> Result<()> {
+    mut feed: Feed,
+  ) -> Result<Feed> {
     let posts = feed.take_posts();
     let mut new_posts = vec![];
 
@@ -182,7 +185,7 @@ impl FeedFilter for Select {
     }
 
     feed.set_posts(new_posts);
-    Ok(())
+    Ok(feed)
   }
 }
 

--- a/src/filter/select.rs
+++ b/src/filter/select.rs
@@ -169,7 +169,7 @@ impl Select {
 impl FeedFilter for Select {
   async fn run(
     &self,
-    _ctx: &FilterContext,
+    _ctx: &mut FilterContext,
     feed: &mut crate::feed::Feed,
   ) -> Result<()> {
     let posts = feed.take_posts();

--- a/src/filter/select.rs
+++ b/src/filter/select.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::util::{ConfigError, Result, SingleOrVec};
 
-use super::{FeedFilter, FeedFilterConfig};
+use super::{FeedFilter, FeedFilterConfig, FilterContext};
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(transparent)]
@@ -167,7 +167,11 @@ impl Select {
 
 #[async_trait::async_trait]
 impl FeedFilter for Select {
-  async fn run(&self, feed: &mut crate::feed::Feed) -> Result<()> {
+  async fn run(
+    &self,
+    _ctx: &FilterContext,
+    feed: &mut crate::feed::Feed,
+  ) -> Result<()> {
     let posts = feed.take_posts();
     let mut new_posts = vec![];
 

--- a/src/filter/simplify_html.rs
+++ b/src/filter/simplify_html.rs
@@ -5,7 +5,7 @@ use url::Url;
 use crate::feed::Feed;
 use crate::util::Result;
 
-use super::{FeedFilter, FeedFilterConfig};
+use super::{FeedFilter, FeedFilterConfig, FilterContext};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SimplifyHtmlConfig {}
@@ -23,7 +23,7 @@ impl FeedFilterConfig for SimplifyHtmlConfig {
 
 #[async_trait::async_trait]
 impl FeedFilter for SimplifyHtmlFilter {
-  async fn run(&self, feed: &mut Feed) -> Result<()> {
+  async fn run(&self, _ctx: &FilterContext, feed: &mut Feed) -> Result<()> {
     let mut posts = feed.take_posts();
 
     for post in &mut posts {

--- a/src/filter/simplify_html.rs
+++ b/src/filter/simplify_html.rs
@@ -23,7 +23,11 @@ impl FeedFilterConfig for SimplifyHtmlConfig {
 
 #[async_trait::async_trait]
 impl FeedFilter for SimplifyHtmlFilter {
-  async fn run(&self, _ctx: &mut FilterContext, feed: &mut Feed) -> Result<()> {
+  async fn run(
+    &self,
+    _ctx: &mut FilterContext,
+    mut feed: Feed,
+  ) -> Result<Feed> {
     let mut posts = feed.take_posts();
 
     for post in &mut posts {
@@ -36,7 +40,7 @@ impl FeedFilter for SimplifyHtmlFilter {
     }
 
     feed.set_posts(posts);
-    Ok(())
+    Ok(feed)
   }
 }
 

--- a/src/filter/simplify_html.rs
+++ b/src/filter/simplify_html.rs
@@ -23,7 +23,7 @@ impl FeedFilterConfig for SimplifyHtmlConfig {
 
 #[async_trait::async_trait]
 impl FeedFilter for SimplifyHtmlFilter {
-  async fn run(&self, _ctx: &FilterContext, feed: &mut Feed) -> Result<()> {
+  async fn run(&self, _ctx: &mut FilterContext, feed: &mut Feed) -> Result<()> {
     let mut posts = feed.take_posts();
 
     for post in &mut posts {

--- a/src/filter_pipeline.rs
+++ b/src/filter_pipeline.rs
@@ -29,23 +29,20 @@ impl FilterPipelineConfig {
 }
 
 impl FilterPipeline {
-  pub async fn process(
-    &self,
-    ctx: &mut FilterContext,
-    feed: &mut Feed,
-  ) -> Result<()> {
-    self.process_partial(feed, ctx, self.filters.len()).await
+  pub async fn run(
+    &mut self,
+    mut feed: Feed,
+    mut context: FilterContext,
+    limit_filters: Option<usize>,
+  ) -> Result<Feed> {
+    let limit_filters = limit_filters.unwrap_or_else(|| self.num_filters());
+    for filter in self.filters.iter().take(limit_filters) {
+      filter.run(&mut context, &mut feed).await?;
+    }
+    Ok(feed)
   }
 
-  pub async fn process_partial(
-    &self,
-    feed: &mut Feed,
-    ctx: &mut FilterContext,
-    limit_filters: usize,
-  ) -> Result<()> {
-    for filter in self.filters.iter().take(limit_filters) {
-      filter.run(ctx, feed).await?;
-    }
-    Ok(())
+  pub fn num_filters(&self) -> usize {
+    self.filters.len()
   }
 }

--- a/src/filter_pipeline.rs
+++ b/src/filter_pipeline.rs
@@ -37,7 +37,7 @@ impl FilterPipeline {
     let limit_filters =
       context.limit_filters.unwrap_or_else(|| self.num_filters());
     for filter in self.filters.iter().take(limit_filters) {
-      filter.run(&mut context, &mut feed).await?;
+      feed = filter.run(&mut context, feed).await?;
     }
     Ok(feed)
   }

--- a/src/filter_pipeline.rs
+++ b/src/filter_pipeline.rs
@@ -1,0 +1,51 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+  feed::Feed,
+  filter::{BoxedFilter, FeedFilter, FilterConfig, FilterContext},
+  util::Result,
+};
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
+#[serde(transparent)]
+pub struct FilterPipelineConfig {
+  filters: Vec<FilterConfig>,
+}
+
+#[derive(Clone)]
+pub struct FilterPipeline {
+  filters: Vec<BoxedFilter>,
+}
+
+impl FilterPipelineConfig {
+  pub async fn build(self) -> Result<FilterPipeline> {
+    let mut filters = Vec::new();
+    for filter_config in self.filters {
+      let filter = filter_config.build().await?;
+      filters.push(filter);
+    }
+    Ok(FilterPipeline { filters })
+  }
+}
+
+impl FilterPipeline {
+  pub async fn process(
+    &self,
+    ctx: &mut FilterContext,
+    feed: &mut Feed,
+  ) -> Result<()> {
+    self.process_partial(feed, ctx, self.filters.len()).await
+  }
+
+  pub async fn process_partial(
+    &self,
+    feed: &mut Feed,
+    ctx: &mut FilterContext,
+    limit_filters: usize,
+  ) -> Result<()> {
+    for filter in self.filters.iter().take(limit_filters) {
+      filter.run(ctx, feed).await?;
+    }
+    Ok(())
+  }
+}

--- a/src/filter_pipeline.rs
+++ b/src/filter_pipeline.rs
@@ -30,12 +30,12 @@ impl FilterPipelineConfig {
 
 impl FilterPipeline {
   pub async fn run(
-    &mut self,
-    mut feed: Feed,
+    &self,
     mut context: FilterContext,
-    limit_filters: Option<usize>,
+    mut feed: Feed,
   ) -> Result<Feed> {
-    let limit_filters = limit_filters.unwrap_or_else(|| self.num_filters());
+    let limit_filters =
+      context.limit_filters.unwrap_or_else(|| self.num_filters());
     for filter in self.filters.iter().take(limit_filters) {
       filter.run(&mut context, &mut feed).await?;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod client;
 mod config;
 mod feed;
 mod filter;
+mod filter_pipeline;
 mod html;
 mod js;
 mod server;

--- a/src/server/endpoint.rs
+++ b/src/server/endpoint.rs
@@ -246,15 +246,15 @@ impl EndpointService {
   ) -> Result<EndpointOutcome> {
     let source = self.find_source(&param.source)?;
     let mut feed = source.fetch_feed(Some(&self.client), None).await?;
-    let context = FilterContext::new();
+    let mut context = FilterContext::new();
 
     if let Some(limit) = param.limit_filters {
       self
         .filters
-        .process_partial(&mut feed, &context, limit)
+        .process_partial(&mut feed, &mut context, limit)
         .await?;
     } else {
-      self.filters.process(&context, &mut feed).await?;
+      self.filters.process(&mut context, &mut feed).await?;
     }
 
     if let Some(limit) = param.limit_posts {


### PR DESCRIPTION
Prior to this change, the `FeedFilter` trait is defined as follows:

``` rust
pub trait FeedFilter {
  async fn run(&self, feed: &mut Feed) -> Result<()>;
}
```

Now I want to change the `FeedFilter` trait to be as follows:

``` rust
pub trait FeedFilter {
  async fn run(&self, ctx: &mut FilterContext, feed: Feed) -> Result<Feed>;
}
```

There are two major changes made to this interface.

First, the `run` method now takes a `FilterContext` that can be used to store and retrieve state. The can `FilterContext` is used to influence the behavior of filters. Currently no filter uses this context yet. But I plan to put the base address from the request to the context so that the `client` downstream can use this information to reconstruct absolute url from relative urls. (c.f. #36)

Secondly, I modified the `feed` parameter to allow each filter to take full ownership of the feed. The main reason is that I hope to define a `FeedFilter` as to a **stateful endofunction on a Feed** (or more precisely: an async, fallible, and stateful endofunction). I think the new type more clearly indicates its nature. The original signature hints that a filter somehow "modifies" a feed, which is slightly different conceptually.

-------

In addition to the above changes, I also extracted the `FilterPipeline` type into a standalone module. The concept was previously known as `Filters`, but I dislike terrible naming.