### PR TITLE
feat: feature flag to disable inspector-ui on build time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1337,30 +1337,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
-name = "maud"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df518b75016b4289cdddffa1b01f2122f4a49802c93191f3133f6dc2472ebcaa"
-dependencies = [
- "axum-core",
- "http 1.0.0",
- "itoa 1.0.10",
- "maud_macros",
-]
-
-[[package]]
-name = "maud_macros"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa453238ec218da0af6b11fc5978d3b5c3a45ed97b722391a2a11f3306274e18"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.41",
-]
-
-[[package]]
 name = "memchr"
 version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2110,7 +2086,6 @@ dependencies = [
  "itertools",
  "lazy_static",
  "lru",
- "maud",
  "mime",
  "notify",
  "paste",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ documentation = "https://docs.rs/rss-funnel"
 keywords = ["rss", "feed", "cli"]
 categories = ["command-line-interface", "web-programming"]
 
+[features]
+default = ["inspector-ui"]
+inspector-ui = ["dep:rust-embed"]
+
 [dependencies]
 # Async runtime, utility and helper crates
 async-trait = "0.1.74"
@@ -42,7 +46,7 @@ mime = "0.3.17"
 
 # webui (inspector) support
 maud = { version = "0.26.0", features = ["axum"] }
-rust-embed = { version = "8.2.0", features = ["include-exclude"] }
+rust-embed = { version = "8.2.0", features = ["include-exclude"], optional = true }
 
 # HTML manipulation in the feeds
 scraper = "0.18.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ url = { version = "2.5.0", features = ["serde"] }
 mime = "0.3.17"
 
 # webui (inspector) support
-maud = { version = "0.26.0", features = ["axum"] }
 rust-embed = { version = "8.2.0", features = ["include-exclude"], optional = true }
 
 # HTML manipulation in the feeds

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "inspector")]
 pub use crate::cli::FeedDefinition;
 // pub use crate::client::ClientConfig;
 // pub use crate::filter::FilterConfig;

--- a/src/server/inspector.rs
+++ b/src/server/inspector.rs
@@ -4,7 +4,6 @@ use axum::response::{IntoResponse, Redirect, Response};
 use axum::Json;
 use axum::{routing::get, Extension, Router};
 use http::{StatusCode, Uri};
-// use maud::{html, Markup};
 
 use crate::config::{self, FeedDefinition};
 use crate::util::Error;


### PR DESCRIPTION
The Inspector UI is now enabled by a feature flag named `inspector-ui`. The feature is by default enabled. One can disable it during in build time with `--no-default-filters` flag in `cargo build` command.

Fixes #33.