### PR TITLE
feat(filters): add `note` filter

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -14,37 +14,6 @@ use url::Url;
 
 use crate::{feed::Feed, util::Result};
 
-#[async_trait::async_trait]
-pub trait FeedFilter {
-  async fn run(&self, ctx: &mut FilterContext, feed: Feed) -> Result<Feed>;
-}
-
-#[async_trait::async_trait]
-pub trait FeedFilterConfig {
-  type Filter: FeedFilter;
-
-  async fn build(self) -> Result<Self::Filter>;
-}
-
-#[derive(Clone)]
-pub struct BoxedFilter(Arc<dyn FeedFilter + Send + Sync>);
-
-#[async_trait::async_trait]
-impl FeedFilter for BoxedFilter {
-  async fn run(&self, ctx: &mut FilterContext, feed: Feed) -> Result<Feed> {
-    self.0.run(ctx, feed).await
-  }
-}
-
-impl BoxedFilter {
-  fn from<T>(filter: T) -> Self
-  where
-    T: FeedFilter + Send + Sync + 'static,
-  {
-    Self(Arc::new(filter))
-  }
-}
-
 #[derive(Clone)]
 pub struct FilterContext {
   limit_filters: Option<usize>,
@@ -85,23 +54,34 @@ impl FilterContext {
   }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct SharedFilterField<T> {
-  #[serde(flatten)]
-  inner: T,
-  #[serde(default)]
-  note: Option<String>,
+#[async_trait::async_trait]
+pub trait FeedFilter {
+  async fn run(&self, ctx: &mut FilterContext, feed: Feed) -> Result<Feed>;
 }
 
 #[async_trait::async_trait]
-impl<T> FeedFilterConfig for SharedFilterField<T>
-where
-  T: FeedFilterConfig + Send,
-{
-  type Filter = T::Filter;
+pub trait FeedFilterConfig {
+  type Filter: FeedFilter;
 
-  async fn build(self) -> Result<Self::Filter> {
-    self.inner.build().await
+  async fn build(self) -> Result<Self::Filter>;
+}
+
+#[derive(Clone)]
+pub struct BoxedFilter(Arc<dyn FeedFilter + Send + Sync>);
+
+#[async_trait::async_trait]
+impl FeedFilter for BoxedFilter {
+  async fn run(&self, ctx: &mut FilterContext, feed: Feed) -> Result<Feed> {
+    self.0.run(ctx, feed).await
+  }
+}
+
+impl BoxedFilter {
+  fn from<T>(filter: T) -> Self
+  where
+    T: FeedFilter + Send + Sync + 'static,
+  {
+    Self(Arc::new(filter))
   }
 }
 
@@ -111,7 +91,7 @@ macro_rules! define_filters {
     #[serde(rename_all = "snake_case")]
     pub enum FilterConfig {
       $(
-       $variant(SharedFilterField<$config>),
+        $variant($config),
       )*
     }
 

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -86,15 +86,6 @@ impl BoxedFilter {
   }
 }
 
-pub struct IdentityFilter;
-
-#[async_trait::async_trait]
-impl FeedFilter for IdentityFilter {
-  async fn run(&self, _ctx: &mut FilterContext, feed: Feed) -> Result<Feed> {
-    Ok(feed)
-  }
-}
-
 macro_rules! define_filters {
   ($($variant:ident => $config:ty);* ;) => {
     #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -3,6 +3,7 @@ mod highlight;
 mod html;
 mod js;
 mod merge;
+mod note;
 mod sanitize;
 mod select;
 mod simplify_html;

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -148,4 +148,5 @@ define_filters!(
   Discard => select::DiscardConfig;
   Highlight => highlight::HighlightConfig;
   Merge => merge::MergeConfig;
+  Note => note::NoteFilterConfig;
 );

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -85,6 +85,15 @@ impl BoxedFilter {
   }
 }
 
+pub struct IdentityFilter;
+
+#[async_trait::async_trait]
+impl FeedFilter for IdentityFilter {
+  async fn run(&self, _ctx: &mut FilterContext, feed: Feed) -> Result<Feed> {
+    Ok(feed)
+  }
+}
+
 macro_rules! define_filters {
   ($($variant:ident => $config:ty);* ;) => {
     #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/src/filter/note.rs
+++ b/src/filter/note.rs
@@ -1,0 +1,19 @@
+use serde::{Deserialize, Serialize};
+
+use super::{FeedFilterConfig, IdentityFilter};
+use crate::util::Result;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(transparent)]
+pub struct NoteFilterConfig {
+  note: String,
+}
+
+#[async_trait::async_trait]
+impl FeedFilterConfig for NoteFilterConfig {
+  type Filter = IdentityFilter;
+
+  async fn build(self) -> Result<Self::Filter> {
+    Ok(IdentityFilter)
+  }
+}

--- a/src/filter/note.rs
+++ b/src/filter/note.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
-use super::{FeedFilterConfig, IdentityFilter};
-use crate::util::Result;
+use super::{FeedFilter, FeedFilterConfig, FilterContext};
+use crate::{feed::Feed, util::Result};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(transparent)]
@@ -11,9 +11,18 @@ pub struct NoteFilterConfig {
 
 #[async_trait::async_trait]
 impl FeedFilterConfig for NoteFilterConfig {
-  type Filter = IdentityFilter;
+  type Filter = NoteFilter;
 
   async fn build(self) -> Result<Self::Filter> {
-    Ok(IdentityFilter)
+    Ok(NoteFilter)
+  }
+}
+
+pub struct NoteFilter;
+
+#[async_trait::async_trait]
+impl FeedFilter for NoteFilter {
+  async fn run(&self, _ctx: &mut FilterContext, feed: Feed) -> Result<Feed> {
+    Ok(feed)
   }
 }


### PR DESCRIPTION
This filter allows you to add comments. Just insert a `note: <your comment>` line in the filter list.

The `note` filter does not affect the pipeline in any way, although it does count as a filter in the `limit_filters` setting.

Example:

```yaml
- path: /foo.xml
  source: https://example.com/foo.xml
  note: This is the note for the endpoint
  filters:
    - full_text: {}
    - note: You can add a note filter to add comments to the pipeline.
    - merge: https://example.com/bar.xml
    - note: |
        This is a multiline note.
        It can be useful to add more detailed comments.
```

---------

An alternative approach I considered was to add a `note` field to all filters. However, this approach is limited because many filters are configured not as a struct. Often the case the config is just a single literal value, or a list of values. It would be inconsistent to add `note` field to those filters. I made an attempt in 2a387019113b3e322ad5194c54673c9f733d4519, but reverted it due to the above reason.