### PR TITLE
feat(filters): add `modify_post` and `modify_feed` filters

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -129,6 +129,8 @@ macro_rules! define_filters {
 
 define_filters!(
   Js => js::JsConfig;
+  ModifyPost => js::ModifyPostConfig;
+  ModifyFeed => js::ModifyFeedConfig;
   FullText => full_text::FullTextConfig;
   SimplifyHtml => simplify_html::SimplifyHtmlConfig;
   RemoveElement => html::RemoveElementConfig;

--- a/src/filter/js.rs
+++ b/src/filter/js.rs
@@ -169,4 +169,35 @@ mod tests {
       assert!(post.title().unwrap().ends_with(" (modified)"));
     }
   }
+
+  #[tokio::test]
+  async fn test_modify_post_filter() {
+    let config = r#"
+      !endpoint
+      path: /feed.xml
+      source: fixture:///scishow.xml
+      filters:
+        - modify_post: post.title += " (modified)";
+    "#;
+
+    let mut feed = fetch_endpoint(config, "").await;
+    let posts = feed.take_posts();
+    for post in posts {
+      assert!(post.title().unwrap().ends_with(" (modified)"));
+    }
+  }
+
+  #[tokio::test]
+  async fn test_modify_feed_filter() {
+    let config = r#"
+      !endpoint
+      path: /feed.xml
+      source: fixture:///scishow.xml
+      filters:
+        - modify_feed: feed.title.value = "Modified Feed";
+    "#;
+
+    let feed = fetch_endpoint(config, "").await;
+    assert_eq!(feed.title(), "Modified Feed");
+  }
 }

--- a/src/filter/js.rs
+++ b/src/filter/js.rs
@@ -17,6 +17,18 @@ pub struct JsFilter {
   runtime: Runtime,
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(transparent)]
+pub struct ModifyPostConfig {
+  code: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(transparent)]
+pub struct ModifyFeedConfig {
+  code: String,
+}
+
 #[async_trait::async_trait]
 impl FeedFilterConfig for JsConfig {
   type Filter = JsFilter;
@@ -26,6 +38,32 @@ impl FeedFilterConfig for JsConfig {
     runtime.eval(&self.code).await?;
 
     Ok(Self::Filter { runtime })
+  }
+}
+
+#[async_trait::async_trait]
+impl FeedFilterConfig for ModifyPostConfig {
+  type Filter = JsFilter;
+
+  async fn build(self) -> Result<Self::Filter> {
+    let code = format!(
+      "function modify_post(feed, post) {{ {}; return post; }}",
+      self.code
+    );
+    JsConfig { code }.build().await
+  }
+}
+
+#[async_trait::async_trait]
+impl FeedFilterConfig for ModifyFeedConfig {
+  type Filter = JsFilter;
+
+  async fn build(self) -> Result<Self::Filter> {
+    let code = format!(
+      "function modify_feed(feed) {{ {}; return feed; }}",
+      self.code
+    );
+    JsConfig { code }.build().await
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/shouya/rss-funnel/issues/38.

The config syntax looks like:

``` yaml
filters:
  - modify_post: |
        if (feed.title === 'Hacker News') {
          post.title = post.title.replace('Show HN: ', '');
        }
  - modify_feed: feed.title = 'HN';
```

This implementation is quick and dirty as it merely template the code in `modify_post` and `modify_feed` like this:

``` javascript
function modify_post(feed, post) {
  <your code>;
  return post;
}
```