### PR TITLE
refactor(server): optimize reload logic

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -65,16 +65,17 @@ impl TestConfig {
   }
 }
 
-#[derive(JsonSchema, Serialize, Deserialize, Clone, Debug)]
+#[derive(
+  JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
+)]
 pub struct FeedDefinition {
   pub endpoints: Vec<EndpointConfig>,
 }
 
 impl FeedDefinition {
-  pub fn load_from_file(path: &Path) -> Result<Self> {
+  pub fn load_from_file(path: &Path) -> Result<Self, ConfigError> {
     let f = std::fs::File::open(path)?;
-    let feed_definition =
-      serde_yaml::from_reader(f).map_err(ConfigError::from)?;
+    let feed_definition: Self = serde_yaml::from_reader(f)?;
     Ok(feed_definition)
   }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -115,7 +115,7 @@ async fn test_endpoint(feed_defn: FeedDefinition, test_config: &TestConfig) {
     return;
   };
   let mut endpoint_service = endpoint_conf
-    .into_service()
+    .build()
     .await
     .expect("failed to build endpoint service");
   let endpoint_param = test_config.to_endpoint_param();

--- a/src/client.rs
+++ b/src/client.rs
@@ -7,7 +7,10 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-use crate::{feed::Feed, util::Result};
+use crate::{
+  feed::Feed,
+  util::{ConfigError, Result},
+};
 
 use self::cache::{Response, ResponseCache};
 
@@ -104,7 +107,10 @@ impl ClientConfig {
     builder
   }
 
-  pub fn build(&self, default_cache_ttl: Duration) -> Result<Client> {
+  pub fn build(
+    &self,
+    default_cache_ttl: Duration,
+  ) -> Result<Client, ConfigError> {
     let reqwest_client = self.to_builder().build()?;
     let client = Client::new(
       self.cache_size.unwrap_or(64),

--- a/src/client.rs
+++ b/src/client.rs
@@ -19,7 +19,9 @@ struct HttpFixture {
   content: String,
 }
 
-#[derive(JsonSchema, Serialize, Deserialize, Debug, Clone)]
+#[derive(
+  JsonSchema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash,
+)]
 pub struct ClientConfig {
   /// The "user-agent" header to send with requests
   user_agent: Option<String>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
-#[cfg(feature = "inspector-ui")]
-pub use crate::cli::FeedDefinition;
+// #[cfg(feature = "inspector-ui")]
+// pub use crate::cli::FeedDefinition;
 // pub use crate::client::ClientConfig;
 // pub use crate::filter::FilterConfig;
 // pub use crate::server::endpoint::{EndpointConfig, EndpointServiceConfig};

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -18,7 +18,9 @@ pub enum Feed {
   Atom(atom_syndication::Feed),
 }
 
-#[derive(JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(
+  JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
+)]
 #[serde(rename_all = "lowercase")]
 pub enum FeedFormat {
   /// RSS 2.0

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -130,6 +130,12 @@ macro_rules! define_filters {
         }
       }
 
+      pub fn name(&self) -> &'static str {
+        match self {
+          $(FilterConfig::$variant(_) => paste::paste! {stringify!([<$variant:snake>])},)*
+        }
+      }
+
       pub fn schema_for_all() -> HashMap<String, schemars::schema::RootSchema> {
         let settings = schemars::gen::SchemaSettings::draft07().with(|s| {
           s.option_nullable = true;

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -15,7 +15,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-use crate::{feed::Feed, util::Result};
+use crate::{feed::Feed, util::ConfigError, util::Result};
 
 #[derive(Clone)]
 pub struct FilterContext {
@@ -66,7 +66,7 @@ pub trait FeedFilter {
 pub trait FeedFilterConfig {
   type Filter: FeedFilter;
 
-  async fn build(self) -> Result<Self::Filter>;
+  async fn build(self) -> Result<Self::Filter, ConfigError>;
 }
 
 #[derive(Clone)]
@@ -121,7 +121,7 @@ macro_rules! define_filters {
         }
       }
 
-      pub async fn build(self) -> Result<BoxedFilter> {
+      pub async fn build(self) -> Result<BoxedFilter, ConfigError> {
         match self {
           $(FilterConfig::$variant(config) => {
             let filter = config.build().await?;

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -91,7 +91,7 @@ impl BoxedFilter {
 macro_rules! define_filters {
   ($($variant:ident => $config:ty, $desc:literal);* ;) => {
     paste::paste! {
-      #[derive(JsonSchema, Serialize, Deserialize, Clone, Debug)]
+      #[derive(JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
       #[serde(rename_all = "snake_case")]
       pub enum FilterConfig {
         $(

--- a/src/filter/full_text.rs
+++ b/src/filter/full_text.rs
@@ -9,7 +9,7 @@ use url::Url;
 use crate::client::{self, Client};
 use crate::feed::{Feed, Post};
 use crate::html::convert_relative_url;
-use crate::util::{Error, Result};
+use crate::util::{ConfigError, Error, Result};
 
 use super::html::{KeepElement, KeepElementConfig};
 use super::{FeedFilter, FeedFilterConfig, FilterContext};
@@ -47,7 +47,7 @@ pub struct FullTextFilter {
 impl FeedFilterConfig for FullTextConfig {
   type Filter = FullTextFilter;
 
-  async fn build(self) -> Result<Self::Filter> {
+  async fn build(self) -> Result<Self::Filter, ConfigError> {
     // default cache ttl is 12 hours
     let default_cache_ttl = Duration::from_secs(12 * 60 * 60);
     let client = self.client.unwrap_or_default().build(default_cache_ttl)?;

--- a/src/filter/full_text.rs
+++ b/src/filter/full_text.rs
@@ -16,7 +16,9 @@ use super::{FeedFilter, FeedFilterConfig, FilterContext};
 
 const DEFAULT_PARALLELISM: usize = 20;
 
-#[derive(JsonSchema, Serialize, Deserialize, Debug, Clone)]
+#[derive(
+  JsonSchema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash,
+)]
 pub struct FullTextConfig {
   /// The maximum number of concurrent requests
   parallelism: Option<usize>,

--- a/src/filter/highlight.rs
+++ b/src/filter/highlight.rs
@@ -11,7 +11,9 @@ use crate::{
   util::{ConfigError, Result},
 };
 
-#[derive(JsonSchema, Serialize, Deserialize, Clone, Debug)]
+#[derive(
+  JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
+)]
 /// Highlight the given keywords in the feed's description
 pub struct HighlightConfig {
   #[serde(flatten)]
@@ -20,7 +22,9 @@ pub struct HighlightConfig {
   bg_color: Option<String>,
 }
 
-#[derive(JsonSchema, Serialize, Deserialize, Clone, Debug)]
+#[derive(
+  JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
+)]
 #[serde(untagged)]
 enum KeywordsOrPatterns {
   /// A list of keywords to highlight

--- a/src/filter/html.rs
+++ b/src/filter/html.rs
@@ -24,7 +24,9 @@ use super::{FeedFilter, FeedFilterConfig, FilterContext};
 ///       - img[src$=".gif"]<br>
 ///       - span.ads
 #[doc(alias = "remove_element")]
-#[derive(JsonSchema, Serialize, Deserialize, Clone, Debug)]
+#[derive(
+  JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
+)]
 #[serde(transparent)]
 pub struct RemoveElementConfig {
   selectors: Vec<String>,
@@ -107,7 +109,9 @@ impl FeedFilter for RemoveElement {
 /// ```yaml
 ///   - keep_element: img[src$=".gif"]
 /// ```
-#[derive(JsonSchema, Serialize, Deserialize, Debug, Clone)]
+#[derive(
+  JsonSchema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash,
+)]
 #[serde(transparent)]
 pub struct KeepElementConfig {
   selector: String,
@@ -188,7 +192,9 @@ impl FeedFilter for KeepElement {
   }
 }
 
-#[derive(JsonSchema, Serialize, Deserialize, Clone, Debug)]
+#[derive(
+  JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
+)]
 pub struct SplitConfig {
   /// The CSS selector for the title elements. The textContent of the
   /// selected elements will be used.

--- a/src/filter/js.rs
+++ b/src/filter/js.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::feed::Feed;
 use crate::js::{AsJson, Runtime};
-use crate::util::{Error, Result};
+use crate::util::{ConfigError, Error, Result};
 
 use super::{FeedFilter, FeedFilterConfig, FilterContext};
 
@@ -53,7 +53,7 @@ pub struct JsFilter {
 impl FeedFilterConfig for JsConfig {
   type Filter = JsFilter;
 
-  async fn build(self) -> Result<Self::Filter> {
+  async fn build(self) -> Result<Self::Filter, ConfigError> {
     let runtime = Runtime::new().await?;
     runtime.eval(&self.code).await?;
 
@@ -65,7 +65,7 @@ impl FeedFilterConfig for JsConfig {
 impl FeedFilterConfig for ModifyPostConfig {
   type Filter = JsFilter;
 
-  async fn build(self) -> Result<Self::Filter> {
+  async fn build(self) -> Result<Self::Filter, ConfigError> {
     let code = format!(
       "function modify_post(feed, post) {{ {}; return post; }}",
       self.code
@@ -78,7 +78,7 @@ impl FeedFilterConfig for ModifyPostConfig {
 impl FeedFilterConfig for ModifyFeedConfig {
   type Filter = JsFilter;
 
-  async fn build(self) -> Result<Self::Filter> {
+  async fn build(self) -> Result<Self::Filter, ConfigError> {
     let code = format!(
       "function modify_feed(feed) {{ {}; return feed; }}",
       self.code

--- a/src/filter/js.rs
+++ b/src/filter/js.rs
@@ -7,7 +7,9 @@ use crate::util::{Error, Result};
 
 use super::{FeedFilter, FeedFilterConfig, FilterContext};
 
-#[derive(JsonSchema, Serialize, Deserialize, Clone, Debug)]
+#[derive(
+  JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
+)]
 #[serde(transparent)]
 /// Either define a function `modify_feed` or `modify_post` to modify the feed or posts respectively.
 /// <br><br>
@@ -17,7 +19,9 @@ pub struct JsConfig {
   code: String,
 }
 
-#[derive(JsonSchema, Serialize, Deserialize, Clone, Debug)]
+#[derive(
+  JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
+)]
 #[serde(transparent)]
 /// JavaScript code for for editing post. Modify `post` variable to update the post or set it to null to delete it.
 /// <br><br>
@@ -28,7 +32,9 @@ pub struct ModifyPostConfig {
   code: String,
 }
 
-#[derive(JsonSchema, Serialize, Deserialize, Clone, Debug)]
+#[derive(
+  JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
+)]
 #[serde(transparent)]
 /// JavaScript code for for editing feed. Modify `feed` variable to update the feed.
 /// <br><br>

--- a/src/filter/merge.rs
+++ b/src/filter/merge.rs
@@ -9,7 +9,7 @@ use crate::client::{Client, ClientConfig};
 use crate::feed::Feed;
 use crate::filter_pipeline::{FilterPipeline, FilterPipelineConfig};
 use crate::source::{Source, SourceConfig};
-use crate::util::{Result, SingleOrVec};
+use crate::util::{ConfigError, Result, SingleOrVec};
 
 use super::{FeedFilter, FeedFilterConfig, FilterContext};
 
@@ -73,7 +73,7 @@ impl From<MergeConfig> for MergeFullConfig {
 impl FeedFilterConfig for MergeConfig {
   type Filter = Merge;
 
-  async fn build(self) -> Result<Self::Filter> {
+  async fn build(self) -> Result<Self::Filter, ConfigError> {
     let MergeFullConfig {
       client,
       filters,

--- a/src/filter/merge.rs
+++ b/src/filter/merge.rs
@@ -13,7 +13,9 @@ use crate::util::{Result, SingleOrVec};
 
 use super::{FeedFilter, FeedFilterConfig, FilterContext};
 
-#[derive(JsonSchema, Serialize, Deserialize, Clone, Debug)]
+#[derive(
+  JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
+)]
 #[serde(untagged)]
 pub enum MergeConfig {
   /// Simple merge with default client and no filters
@@ -22,13 +24,17 @@ pub enum MergeConfig {
   Full(MergeFullConfig),
 }
 
-#[derive(JsonSchema, Serialize, Deserialize, Clone, Debug)]
+#[derive(
+  JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
+)]
 #[serde(transparent)]
 pub struct MergeSimpleConfig {
   source: SingleOrVec<SourceConfig>,
 }
 
-#[derive(JsonSchema, Serialize, Deserialize, Clone, Debug)]
+#[derive(
+  JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
+)]
 pub struct MergeFullConfig {
   /// Source configuration
   source: SingleOrVec<SourceConfig>,

--- a/src/filter/note.rs
+++ b/src/filter/note.rs
@@ -2,7 +2,10 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::{FeedFilter, FeedFilterConfig, FilterContext};
-use crate::{feed::Feed, util::Result};
+use crate::{
+  feed::Feed,
+  util::{ConfigError, Result},
+};
 
 #[derive(
   JsonSchema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash,
@@ -18,7 +21,7 @@ pub struct NoteFilterConfig {
 impl FeedFilterConfig for NoteFilterConfig {
   type Filter = NoteFilter;
 
-  async fn build(self) -> Result<Self::Filter> {
+  async fn build(self) -> Result<Self::Filter, ConfigError> {
     Ok(NoteFilter)
   }
 }

--- a/src/filter/note.rs
+++ b/src/filter/note.rs
@@ -4,7 +4,9 @@ use serde::{Deserialize, Serialize};
 use super::{FeedFilter, FeedFilterConfig, FilterContext};
 use crate::{feed::Feed, util::Result};
 
-#[derive(JsonSchema, Serialize, Deserialize, Debug, Clone)]
+#[derive(
+  JsonSchema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash,
+)]
 #[serde(transparent)]
 /// The note filter has no effect. It serves only documentation
 /// purposes.

--- a/src/filter/sanitize.rs
+++ b/src/filter/sanitize.rs
@@ -9,13 +9,17 @@ use crate::{feed::Feed, util::ConfigError};
 
 use super::{FeedFilter, FeedFilterConfig, FilterContext};
 
-#[derive(JsonSchema, Serialize, Deserialize, Clone, Debug)]
+#[derive(
+  JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
+)]
 struct SanitizeOpReplaceConfig {
   from: String,
   to: String,
 }
 
-#[derive(JsonSchema, Serialize, Deserialize, Clone, Debug)]
+#[derive(
+  JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
+)]
 pub struct SanitizeOpConfig {
   /// Remove all occurrences of the string
   remove: Option<String>,
@@ -78,7 +82,9 @@ pub enum SanitizeOp {
   Replace(Regex, String),
 }
 
-#[derive(JsonSchema, Serialize, Deserialize, Clone, Debug)]
+#[derive(
+  JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
+)]
 #[serde(transparent)]
 pub struct SanitizeConfig {
   ops: Vec<SanitizeOpConfig>,

--- a/src/filter/sanitize.rs
+++ b/src/filter/sanitize.rs
@@ -32,7 +32,7 @@ pub struct SanitizeOpConfig {
 }
 
 impl SanitizeOpConfig {
-  fn into_op(self) -> Result<SanitizeOp> {
+  fn into_op(self) -> Result<SanitizeOp, ConfigError> {
     // must ensure that only one of the options is Some
     let num_selected = self.remove.is_some() as u8
       + self.remove_regex.is_some() as u8
@@ -43,7 +43,7 @@ impl SanitizeOpConfig {
         "Exactly one of {}, {}, {}, {} must be specified for `sanitize' filter",
         "remove", "remove_regex", "replace", "replace_regex"
       );
-      return Err(ConfigError::Message(message.to_string()).into());
+      return Err(ConfigError::Message(message.to_string()));
     }
 
     macro_rules! parse_regex {
@@ -98,7 +98,7 @@ pub struct Sanitize {
 impl FeedFilterConfig for SanitizeConfig {
   type Filter = Sanitize;
 
-  async fn build(self) -> Result<Self::Filter> {
+  async fn build(self) -> Result<Self::Filter, ConfigError> {
     let mut ops = Vec::new();
     for conf in self.ops {
       ops.push(conf.into_op()?);

--- a/src/filter/select.rs
+++ b/src/filter/select.rs
@@ -11,17 +11,23 @@ use crate::{
 
 use super::{FeedFilter, FeedFilterConfig, FilterContext};
 
-#[derive(JsonSchema, Serialize, Deserialize, Clone, Debug)]
+#[derive(
+  JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
+)]
 #[serde(transparent)]
 /// Keep only posts that match the given criteria
 pub struct KeepOnlyConfig(AnyMatchConfig);
 
-#[derive(JsonSchema, Serialize, Deserialize, Clone, Debug)]
+#[derive(
+  JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
+)]
 #[serde(transparent)]
 /// Discard posts that match the given criteria
 pub struct DiscardConfig(AnyMatchConfig);
 
-#[derive(JsonSchema, Serialize, Deserialize, Clone, Debug)]
+#[derive(
+  JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
+)]
 #[serde(untagged)]
 enum AnyMatchConfig {
   /// Matches posts containing the given string
@@ -32,7 +38,9 @@ enum AnyMatchConfig {
   MatchConfig(MatchConfig),
 }
 
-#[derive(JsonSchema, Serialize, Deserialize, Clone, Debug)]
+#[derive(
+  JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
+)]
 struct MatchConfig {
   /// Regular expression(s) to match
   #[serde(default)]
@@ -108,7 +116,9 @@ impl MatchConfig {
   }
 }
 
-#[derive(JsonSchema, Serialize, Deserialize, Clone, Copy, Debug)]
+#[derive(
+  JsonSchema, Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Hash,
+)]
 #[serde(rename_all = "snake_case")]
 enum Field {
   Title,

--- a/src/filter/select.rs
+++ b/src/filter/select.rs
@@ -100,11 +100,11 @@ impl MatchConfig {
     out
   }
 
-  fn regex_set(&self) -> Result<RegexSet> {
-    Ok(RegexSet::new(self.regexes()).map_err(ConfigError::from)?)
+  fn regex_set(&self) -> Result<RegexSet, ConfigError> {
+    Ok(RegexSet::new(self.regexes())?)
   }
 
-  fn into_select(self, action: Action) -> Result<Select> {
+  fn into_select(self, action: Action) -> Result<Select, ConfigError> {
     let needle = self.regex_set()?;
     let field = self.field;
 
@@ -156,7 +156,7 @@ enum Action {
 impl FeedFilterConfig for KeepOnlyConfig {
   type Filter = Select;
 
-  async fn build(self) -> Result<Self::Filter> {
+  async fn build(self) -> Result<Self::Filter, ConfigError> {
     self.0.into_match_config().into_select(Action::Include)
   }
 }
@@ -165,7 +165,7 @@ impl FeedFilterConfig for KeepOnlyConfig {
 impl FeedFilterConfig for DiscardConfig {
   type Filter = Select;
 
-  async fn build(self) -> Result<Self::Filter> {
+  async fn build(self) -> Result<Self::Filter, ConfigError> {
     self.0.into_match_config().into_select(Action::Exclude)
   }
 }

--- a/src/filter/simplify_html.rs
+++ b/src/filter/simplify_html.rs
@@ -3,8 +3,8 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-use crate::feed::Feed;
 use crate::util::Result;
+use crate::{feed::Feed, util::ConfigError};
 
 use super::{FeedFilter, FeedFilterConfig, FilterContext};
 
@@ -21,7 +21,7 @@ pub struct SimplifyHtmlFilter;
 impl FeedFilterConfig for SimplifyHtmlConfig {
   type Filter = SimplifyHtmlFilter;
 
-  async fn build(self) -> Result<Self::Filter> {
+  async fn build(self) -> Result<Self::Filter, ConfigError> {
     Ok(SimplifyHtmlFilter)
   }
 }

--- a/src/filter/simplify_html.rs
+++ b/src/filter/simplify_html.rs
@@ -8,7 +8,9 @@ use crate::util::Result;
 
 use super::{FeedFilter, FeedFilterConfig, FilterContext};
 
-#[derive(JsonSchema, Serialize, Deserialize, Debug, Clone)]
+#[derive(
+  JsonSchema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash,
+)]
 /// The simplify_html filter simplifies the HTML content of
 /// posts. There is no configuration.
 pub struct SimplifyHtmlConfig {}

--- a/src/filter_pipeline.rs
+++ b/src/filter_pipeline.rs
@@ -7,7 +7,9 @@ use crate::{
   util::Result,
 };
 
-#[derive(JsonSchema, Serialize, Deserialize, Clone, Debug, Default)]
+#[derive(
+  JsonSchema, Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq, Hash,
+)]
 #[serde(transparent)]
 pub struct FilterPipelineConfig {
   filters: Vec<FilterConfig>,

--- a/src/filter_pipeline.rs
+++ b/src/filter_pipeline.rs
@@ -1,5 +1,6 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
 
 use crate::{
   feed::Feed,
@@ -15,19 +16,23 @@ pub struct FilterPipelineConfig {
   filters: Vec<FilterConfig>,
 }
 
-#[derive(Clone)]
 pub struct FilterPipeline {
-  filters: Vec<BoxedFilter>,
+  configs: Mutex<Vec<FilterConfig>>,
+  filters: Mutex<Vec<BoxedFilter>>,
 }
 
 impl FilterPipelineConfig {
   pub async fn build(self) -> Result<FilterPipeline> {
     let mut filters = Vec::new();
+    let configs = self.filters.clone();
     for filter_config in self.filters {
       let filter = filter_config.build().await?;
       filters.push(filter);
     }
-    Ok(FilterPipeline { filters })
+
+    let filters = Mutex::new(filters);
+    let configs = Mutex::new(configs);
+    Ok(FilterPipeline { filters, configs })
   }
 }
 
@@ -40,13 +45,14 @@ impl FilterPipeline {
     let limit_filters = context
       .limit_filters()
       .unwrap_or_else(|| self.num_filters());
-    for filter in self.filters.iter().take(limit_filters) {
+    let filters = self.filters.lock().await;
+    for filter in filters.iter().take(limit_filters) {
       feed = filter.run(&mut context, feed).await?;
     }
     Ok(feed)
   }
 
   pub fn num_filters(&self) -> usize {
-    self.filters.len()
+    self.filters.blocking_lock().len()
   }
 }

--- a/src/filter_pipeline.rs
+++ b/src/filter_pipeline.rs
@@ -5,7 +5,7 @@ use tokio::sync::Mutex;
 use crate::{
   feed::Feed,
   filter::{BoxedFilter, FeedFilter, FilterConfig, FilterContext},
-  util::Result,
+  util::{ConfigError, Result},
 };
 
 #[derive(
@@ -26,7 +26,7 @@ struct Inner {
 }
 
 impl FilterPipelineConfig {
-  pub async fn build(self) -> Result<FilterPipeline> {
+  pub async fn build(self) -> Result<FilterPipeline, ConfigError> {
     let mut filters = vec![];
     let configs = self.filters.clone();
     for filter_config in self.filters {

--- a/src/filter_pipeline.rs
+++ b/src/filter_pipeline.rs
@@ -44,10 +44,6 @@ impl FilterPipeline {
     self.inner.lock().await.run(context, feed).await
   }
 
-  pub fn num_filters(&self) -> usize {
-    self.inner.blocking_lock().num_filters()
-  }
-
   pub async fn update(&self, config: FilterPipelineConfig) -> Result<()> {
     let mut inner = self.inner.lock().await;
     let mut filters = vec![];

--- a/src/filter_pipeline.rs
+++ b/src/filter_pipeline.rs
@@ -1,6 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
+use tracing::info;
 
 use crate::{
   feed::Feed,
@@ -57,6 +58,7 @@ impl FilterPipeline {
       match inner.take(&filter_config) {
         Some(filter) => filters.push(filter),
         None => {
+          info!("building filter: {}", filter_config.name());
           let filter = filter_config.build().await?;
           filters.push(filter);
         }

--- a/src/filter_pipeline.rs
+++ b/src/filter_pipeline.rs
@@ -44,7 +44,10 @@ impl FilterPipeline {
     self.inner.lock().await.run(context, feed).await
   }
 
-  pub async fn update(&self, config: FilterPipelineConfig) -> Result<()> {
+  pub async fn update(
+    &self,
+    config: FilterPipelineConfig,
+  ) -> Result<(), ConfigError> {
     let mut inner = self.inner.lock().await;
     let mut filters = vec![];
     let mut configs = vec![];

--- a/src/js/builtin.rs
+++ b/src/js/builtin.rs
@@ -3,7 +3,7 @@ use rquickjs::{class::Trace, Class, Ctx};
 use super::dom::{Node, DOM};
 use crate::util::Result;
 
-pub(super) fn register_builtin(ctx: &Ctx) -> Result<()> {
+pub(super) fn register_builtin(ctx: &Ctx) -> Result<(), rquickjs::Error> {
   Class::<DOM>::define(&ctx.globals())?;
   Class::<Node>::define(&ctx.globals())?;
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -3,11 +3,10 @@ mod feed_service;
 #[cfg(feature = "inspector-ui")]
 mod inspector;
 
-use std::{path::Path, sync::Arc, time::Duration};
+use std::{path::Path, sync::Arc};
 
-use axum::{routing::get, Router};
+use axum::{routing::get, Extension, Router};
 use clap::Parser;
-use futures::{future, Future};
 use http::StatusCode;
 use tokio::sync::mpsc;
 use tower_http::compression::CompressionLayer;
@@ -18,6 +17,8 @@ use crate::{
   util::{ConfigError, Result},
 };
 pub use endpoint::{EndpointConfig, EndpointOutcome, EndpointParam};
+
+use self::feed_service::FeedService;
 
 #[derive(Parser, Clone)]
 pub struct ServerConfig {
@@ -54,62 +55,40 @@ impl ServerConfig {
   #[allow(unused)]
   pub async fn run_without_fs_watcher(self, config_path: &Path) -> Result<()> {
     let config = FeedDefinition::load_from_file(config_path)?;
-    self.serve(config, future::pending()).await
+    let feed_service = FeedService::try_from(config).await?;
+    self.serve(feed_service).await
   }
 
   pub async fn run_with_fs_watcher(self, config_path: &Path) -> Result<()> {
+    let config = FeedDefinition::load_from_file(config_path)?;
+    let feed_service = FeedService::try_from(config).await?;
+
     // watcher must not be dropped until the end of the function
-    let (_watcher, mut config_update) = fs_watcher(config_path).await?;
-    let Some(config) = config_update.recv().await else {
-      return Err(
-        ConfigError::Message("failed to load initial config".to_string())
-          .into(),
-      );
-    };
-    let (mut tx, mut rx) = mpsc::channel(1);
+    let (_watcher, mut config_update) = fs_watcher(config_path)?;
 
-    let mut task_handle = tokio::task::spawn(
-      self
-        .clone()
-        .serve(config, async move { rx.recv().await.unwrap() }),
-    );
-    let mut config_update = debounce(Duration::from_millis(500), config_update);
+    let feed_service_clone = feed_service.clone();
+    let config_path_clone = config_path.to_owned();
+    tokio::task::spawn(async move {
+      while config_update.recv().await.is_some() {
+        info!("config updated, reloading service");
+        if !feed_service_clone.reload(&config_path_clone).await {
+          warn!("failed to reload config");
+        }
+      }
+    });
 
-    while let Some(new_config) = config_update.recv().await {
-      info!("config updated, restarting server");
-      tx.send(()).await.ok();
-      task_handle.await.ok();
-
-      (tx, rx) = mpsc::channel(1);
-      task_handle = tokio::task::spawn(
-        self
-          .clone()
-          .serve(new_config, async move { rx.recv().await.unwrap() }),
-      );
-    }
-
-    Ok(())
+    self.serve(feed_service).await
   }
 
-  pub async fn serve(
-    self,
-    feed_definition: FeedDefinition,
-    shutdown_signal: impl Future<Output = ()> + Send + 'static,
-  ) -> Result<()> {
+  pub async fn serve(self, feed_service: FeedService) -> Result<()> {
     info!("listening on {}", &self.bind);
     let listener = tokio::net::TcpListener::bind(&*self.bind).await?;
 
     let mut app = Router::new();
 
-    for endpoint_config in feed_definition.clone().endpoints {
-      info!("adding endpoint {}", &endpoint_config.path);
-      let endpoint_route = endpoint_config.into_route().await?;
-      app = app.merge(endpoint_route);
-    }
-
     #[cfg(feature = "inspector-ui")]
     if self.inspector_ui {
-      app = app.nest("/", inspector::router(feed_definition))
+      app = app.nest("/", inspector::router())
     } else {
       app = app.route("/", get(|| async { "rss-funnel is up and running!" }));
     }
@@ -120,6 +99,8 @@ impl ServerConfig {
 
     app = app
       .route("/health", get(|| async { "ok" }))
+      .route("/:endpoint", get(FeedService::handler))
+      .layer(Extension(feed_service))
       .fallback(get(|| async {
         (StatusCode::NOT_FOUND, "Endpoint not found")
       }))
@@ -127,35 +108,20 @@ impl ServerConfig {
 
     info!("starting server");
     let server = axum::serve(listener, app);
-    let server = server.with_graceful_shutdown(shutdown_signal);
 
     Ok(server.await?)
   }
 }
 
-async fn fs_watcher(
+fn fs_watcher(
   config_path: &Path,
-) -> Result<(notify::RecommendedWatcher, mpsc::Receiver<FeedDefinition>)> {
+) -> Result<(notify::RecommendedWatcher, mpsc::Receiver<()>)> {
   use notify::{Event, RecursiveMode, Watcher};
-
   let (tx, rx) = mpsc::channel(1);
-  let feed_definition = FeedDefinition::load_from_file(config_path).unwrap();
 
-  tx.send(feed_definition)
-    .await
-    .expect("failed to send initial feed definition");
-
-  let path = config_path.to_owned();
   let event_handler = move |event: Result<Event, notify::Error>| match event {
     Ok(event) if event.kind.is_modify() => {
-      match FeedDefinition::load_from_file(&path) {
-        Ok(feed_definition) => {
-          tx.blocking_send(feed_definition).unwrap();
-        }
-        Err(e) => {
-          warn!("Invalid config: {:?}", e);
-        }
-      }
+      tx.blocking_send(()).unwrap();
     }
     Ok(_) => {}
     Err(_) => {
@@ -177,27 +143,4 @@ async fn fs_watcher(
     })?;
 
   Ok((watcher, rx))
-}
-
-fn debounce<T: Send + 'static>(
-  duration: std::time::Duration,
-  mut rx: mpsc::Receiver<T>,
-) -> mpsc::Receiver<T> {
-  let (debounced_tx, debounced_rx) = mpsc::channel(1);
-  tokio::task::spawn(async move {
-    let mut last = None;
-    loop {
-      tokio::select! {
-        val = rx.recv() => {
-          last = val;
-        }
-        _ = tokio::time::sleep(duration) => {
-          if let Some(val) = last.take() {
-            debounced_tx.send(val).await.unwrap();
-          }
-        }
-      }
-    }
-  });
-  debounced_rx
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,4 +1,5 @@
 pub(crate) mod endpoint;
+mod feed_service;
 #[cfg(feature = "inspector-ui")]
 mod inspector;
 

--- a/src/server/endpoint.rs
+++ b/src/server/endpoint.rs
@@ -70,6 +70,7 @@ pub struct EndpointServiceConfig {
 // request.
 #[derive(Clone)]
 pub struct EndpointService {
+  // used for detecting changes in the config for partial update
   config: EndpointServiceConfig,
   source: Option<Source>,
   filters: Arc<FilterPipeline>,

--- a/src/server/endpoint.rs
+++ b/src/server/endpoint.rs
@@ -40,11 +40,6 @@ impl EndpointConfig {
     Ok(serde_yaml::from_str(yaml)?)
   }
 
-  pub async fn into_route(self) -> Result<axum::Router> {
-    let endpoint_service = EndpointService::from_config(self.config).await?;
-    Ok(axum::Router::new().nest_service(&self.path, endpoint_service))
-  }
-
   pub async fn build(self) -> Result<EndpointService, ConfigError> {
     EndpointService::from_config(self.config).await
   }

--- a/src/server/endpoint.rs
+++ b/src/server/endpoint.rs
@@ -35,6 +35,10 @@ pub struct EndpointConfig {
 }
 
 impl EndpointConfig {
+  pub fn path_sans_slash(&self) -> &str {
+    self.path.strip_prefix('/').unwrap_or(&self.path)
+  }
+
   #[cfg(test)]
   pub fn parse_yaml(yaml: &str) -> Result<Self, ConfigError> {
     Ok(serde_yaml::from_str(yaml)?)

--- a/src/server/endpoint.rs
+++ b/src/server/endpoint.rs
@@ -24,7 +24,9 @@ use crate::util::{Error, Result};
 type Request = http::Request<Body>;
 type Response = http::Response<Body>;
 
-#[derive(JsonSchema, Serialize, Deserialize, Clone, Debug)]
+#[derive(
+  JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
+)]
 pub struct EndpointConfig {
   pub path: String,
   pub note: Option<String>,
@@ -50,7 +52,9 @@ impl EndpointConfig {
   }
 }
 
-#[derive(JsonSchema, Serialize, Deserialize, Clone, Debug)]
+#[derive(
+  JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
+)]
 pub struct EndpointServiceConfig {
   #[serde(default)]
   source: Option<SourceConfig>,
@@ -64,6 +68,9 @@ pub struct EndpointServiceConfig {
 // MakeService<http::Request, Response=EndpointService>. But axum
 // Router doesn't support nest_make_service yet, so I will just
 // approximate it by making request_context part of the Service input.
+//
+// This type should be kept cheap to clone. It will be cloned for each
+// request.
 #[derive(Clone)]
 pub struct EndpointService {
   source: Option<Source>,

--- a/src/server/endpoint.rs
+++ b/src/server/endpoint.rs
@@ -319,10 +319,15 @@ impl EndpointService {
     }
   }
 
+  pub fn config_changed(&self, config: &EndpointServiceConfig) -> bool {
+    self.config != *config
+  }
+
   pub async fn update(
     mut self,
     config: EndpointServiceConfig,
   ) -> Result<Self, ConfigError> {
+    let cloned_config = config.clone();
     if self.config.client != config.client {
       let default_cache_ttl = Duration::from_secs(15 * 60);
       let client =
@@ -338,6 +343,8 @@ impl EndpointService {
     if self.config.filters != config.filters {
       self.filters.update(config.filters).await?;
     }
+
+    self.config = cloned_config;
 
     Ok(self)
   }

--- a/src/server/feed_service.rs
+++ b/src/server/feed_service.rs
@@ -20,12 +20,37 @@ pub struct FeedService {
 
 struct Inner {
   config_error: Option<ConfigError>,
-  feed_definition: FeedDefinition,
+  feed_definition: Arc<FeedDefinition>,
   // maps path to service
   endpoints: HashMap<String, EndpointService>,
 }
 
 impl FeedService {
+  pub async fn try_from(
+    feed_definition: FeedDefinition,
+  ) -> Result<Self, ConfigError> {
+    let mut endpoints = HashMap::new();
+    for endpoint_config in feed_definition.endpoints.clone() {
+      let path = endpoint_config.path.clone();
+      let endpoint_service = endpoint_config.build().await?;
+      endpoints.insert(path, endpoint_service);
+    }
+
+    let inner = Inner {
+      config_error: None,
+      feed_definition: Arc::new(feed_definition),
+      endpoints,
+    };
+
+    Ok(Self {
+      inner: Arc::new(RwLock::new(inner)),
+    })
+  }
+
+  pub async fn feed_definition(&self) -> Arc<FeedDefinition> {
+    let inner = self.inner.read().await;
+    inner.feed_definition.clone()
+  }
   // Update the feed definition and reconfigure the services. Return true if
   // the reload was successful, false if there was an error.
   pub async fn reload(&self, path: &std::path::Path) -> bool {
@@ -54,30 +79,30 @@ impl FeedService {
       };
     }
 
-    inner.feed_definition = feed_defn;
+    inner.feed_definition = Arc::new(feed_defn);
     inner.endpoints = endpoints;
     true
   }
-}
 
-async fn handler(
-  Path(path): Path<String>,
-  Extension(service): Extension<FeedService>,
-  request: Request,
-) -> Response {
-  let inner = service.inner.read().await;
-  match inner.endpoints.get(&path) {
-    Some(endpoint) => {
-      let mut endpoint = endpoint.clone();
-      endpoint
-        .call(request)
-        .await
-        .expect("infallible endpoint call failed")
+  pub async fn handler(
+    Path(path): Path<String>,
+    Extension(service): Extension<FeedService>,
+    request: Request,
+  ) -> Response {
+    let inner = service.inner.read().await;
+    match inner.endpoints.get(&path) {
+      Some(endpoint) => {
+        let mut endpoint = endpoint.clone();
+        endpoint
+          .call(request)
+          .await
+          .expect("infallible endpoint call failed")
+      }
+      _ => (
+        StatusCode::NOT_FOUND,
+        format!("endpoint not defined: {path}"),
+      )
+        .into_response(),
     }
-    _ => (
-      StatusCode::NOT_FOUND,
-      format!("endpoint not defined: {path}"),
-    )
-      .into_response(),
   }
 }

--- a/src/server/feed_service.rs
+++ b/src/server/feed_service.rs
@@ -1,0 +1,83 @@
+use std::{collections::HashMap, sync::Arc};
+
+use axum::{
+  extract::{Path, Request},
+  response::{IntoResponse, Response},
+  Extension,
+};
+use http::StatusCode;
+use tokio::sync::RwLock;
+use tower::Service;
+
+use crate::{cli::FeedDefinition, util::ConfigError};
+
+use super::endpoint::EndpointService;
+
+#[derive(Clone)]
+pub struct FeedService {
+  inner: Arc<RwLock<Inner>>,
+}
+
+struct Inner {
+  config_error: Option<ConfigError>,
+  feed_definition: FeedDefinition,
+  // maps path to service
+  endpoints: HashMap<String, EndpointService>,
+}
+
+impl FeedService {
+  // Update the feed definition and reconfigure the services. Return true if
+  // the reload was successful, false if there was an error.
+  pub async fn reload(&self, path: &std::path::Path) -> bool {
+    let mut inner = self.inner.write().await;
+    inner.config_error = None;
+    let feed_defn = match FeedDefinition::load_from_file(path) {
+      Err(e) => {
+        inner.config_error = Some(e);
+        return false;
+      }
+      Ok(feed_defn) => feed_defn,
+    };
+
+    let mut endpoints = HashMap::new();
+    for endpoint_config in feed_defn.endpoints.clone() {
+      let path = endpoint_config.path.clone();
+      // TODO: instead of recreating all endpoints, update existing ones.
+      match endpoint_config.build().await {
+        Err(e) => {
+          inner.config_error = Some(e);
+          return false;
+        }
+        Ok(endpoint_service) => {
+          endpoints.insert(path.clone(), endpoint_service);
+        }
+      };
+    }
+
+    inner.feed_definition = feed_defn;
+    inner.endpoints = endpoints;
+    true
+  }
+}
+
+async fn handler(
+  Path(path): Path<String>,
+  Extension(service): Extension<FeedService>,
+  request: Request,
+) -> Response {
+  let inner = service.inner.read().await;
+  match inner.endpoints.get(&path) {
+    Some(endpoint) => {
+      let mut endpoint = endpoint.clone();
+      endpoint
+        .call(request)
+        .await
+        .expect("infallible endpoint call failed")
+    }
+    _ => (
+      StatusCode::NOT_FOUND,
+      format!("endpoint not defined: {path}"),
+    )
+      .into_response(),
+  }
+}

--- a/src/server/feed_service.rs
+++ b/src/server/feed_service.rs
@@ -47,6 +47,14 @@ impl FeedService {
     })
   }
 
+  pub async fn error<R>(&self, callback: impl FnOnce(&ConfigError) -> R) -> R {
+    let inner = self.inner.read().await;
+    match &inner.config_error {
+      Some(e) => callback(e),
+      None => panic!("no error"),
+    }
+  }
+
   pub async fn feed_definition(&self) -> Arc<FeedDefinition> {
     let inner = self.inner.read().await;
     inner.feed_definition.clone()

--- a/src/server/feed_service.rs
+++ b/src/server/feed_service.rs
@@ -31,7 +31,7 @@ impl FeedService {
   ) -> Result<Self, ConfigError> {
     let mut endpoints = HashMap::new();
     for endpoint_config in feed_definition.endpoints.clone() {
-      let path = endpoint_config.path.clone();
+      let path = endpoint_config.path_sans_slash().to_owned();
       let endpoint_service = endpoint_config.build().await?;
       endpoints.insert(path, endpoint_service);
     }
@@ -66,7 +66,7 @@ impl FeedService {
 
     let mut endpoints = HashMap::new();
     for endpoint_config in feed_defn.endpoints.clone() {
-      let path = endpoint_config.path.clone();
+      let path = endpoint_config.path_sans_slash().to_owned();
       // TODO: instead of recreating all endpoints, update existing ones.
       match endpoint_config.build().await {
         Err(e) => {
@@ -100,7 +100,7 @@ impl FeedService {
       }
       _ => (
         StatusCode::NOT_FOUND,
-        format!("endpoint not defined: {path}"),
+        format!("endpoint not defined: /{path}"),
       )
         .into_response(),
     }

--- a/src/source.rs
+++ b/src/source.rs
@@ -8,7 +8,9 @@ use crate::{
   util::{ConfigError, Error, Result},
 };
 
-#[derive(JsonSchema, Serialize, Deserialize, Clone, Debug)]
+#[derive(
+  JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
+)]
 #[serde(untagged)]
 /// # Feed source
 pub enum SourceConfig {
@@ -30,7 +32,9 @@ pub enum Source {
   FromScratch(FromScratch),
 }
 
-#[derive(JsonSchema, Serialize, Deserialize, Clone, Debug)]
+#[derive(
+  JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
+)]
 pub struct FromScratch {
   /// The format of the feed
   pub format: FeedFormat,

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -42,7 +42,7 @@ pub async fn fetch_endpoint(config: &str, query: &str) -> Feed {
   let endpoint_config =
     EndpointConfig::parse_yaml(config).expect("failed to parse config");
   let mut endpoint_service = endpoint_config
-    .into_service()
+    .build()
     .await
     .expect("failed to create service")
     .with_client(dummy_client());

--- a/src/util.rs
+++ b/src/util.rs
@@ -9,6 +9,15 @@ pub const USER_AGENT: &str =
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Debug, thiserror::Error)]
+pub enum JsError {
+  #[error("Js exception {0}")]
+  Exception(String),
+
+  #[error("QuickJS error {0:?}")]
+  Error(#[from] rquickjs::Error),
+}
+
+#[derive(Debug, thiserror::Error)]
 pub enum ConfigError {
   #[error("Bad selector")]
   BadSelector(String),
@@ -21,6 +30,15 @@ pub enum ConfigError {
 
   #[error("Invalid URL {0}")]
   InvalidUrl(#[from] url::ParseError),
+
+  #[error("IO error")]
+  Io(#[from] std::io::Error),
+
+  #[error("Reqwest client error {0:?}")]
+  Reqwest(#[from] reqwest::Error),
+
+  #[error("Js runtime initialization error {0:?}")]
+  Js(#[from] JsError),
 
   #[error("{0}")]
   Message(String),
@@ -58,11 +76,8 @@ pub enum Error {
   #[error("HTTP status error {0:?} (url: {1})")]
   HttpStatus(reqwest::StatusCode, Url),
 
-  #[error("Js execution error {0:?}")]
-  Js(#[from] rquickjs::Error),
-
-  #[error("Js exception {0}")]
-  JsException(String),
+  #[error("Js runtime error {0:?}")]
+  Js(#[from] JsError),
 
   #[error("Failed to extract webpage {0:?}")]
   Readability(#[from] readability::error::Error),

--- a/src/util.rs
+++ b/src/util.rs
@@ -74,7 +74,9 @@ pub enum Error {
   Message(String),
 }
 
-#[derive(JsonSchema, Serialize, Deserialize, Clone, Debug)]
+#[derive(
+  JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
+)]
 #[serde(untagged)]
 pub enum SingleOrVec<T> {
   /// A single entry


### PR DESCRIPTION
The purpose of this branch is to support partial reloading.

Now we will only:

- Only rebuild endpoints whose config changes
- Only rebuild filters whose config changes

If an endpoint's config was untouched, we will reuse the existing endpoint. Same for any filters in the filter pipeline.

There are several benefits with this approach:

- faster, more lightweight reload
- less disruption to caches (e.g. http client cache)
- the server does not need to be restarted on config change
- open up the possibility of notifying and reporting config error to inspector-ui

Aside from some logging changes, this branch should cause no functional difference.

------------

It's not trivial to implement this feature. Doing so requires some architectural change in the server implementation. Previously the routes are statically added to the `axum::Router`. Now since the endpoints can be dynamically added and removed without restarting axum server, I have to implement a custom handler depend on a global instance of current config and endpoint state.

In addition, I made a more clear separation between `Error` and `ConfigError`. Functions that are called during building the config into the service will only raise `ConfigError`. The trait definition for `FeedFilterConfig` has also been updated.