### PR TITLE
perf(filters): parallelize feed post-processing

### DIFF
--- a/src/filter/full_text.rs
+++ b/src/filter/full_text.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use std::time::Duration;
 
 use futures::{stream, StreamExt};
@@ -90,21 +91,23 @@ impl FullTextFilter {
     Ok(text)
   }
 
-  async fn try_fetch_full_post(&self, post: &mut Post) -> Result<()> {
-    let link = post.link_or_err()?;
-    let text = self.fetch_html(link).await?;
-
-    let mut html = scraper::Html::parse_document(&text);
+  fn strip_post_content(
+    html: String,
+    link: &str,
+    simplify: bool,
+    keep_element: Arc<Option<KeepElement>>,
+  ) -> String {
+    let mut html = scraper::Html::parse_document(&html);
     convert_relative_url(&mut html, link);
     let mut text = html.html();
 
-    if self.simplify {
+    if simplify {
       text = super::simplify_html::simplify(&text, link).unwrap_or(text);
     } else {
       text = crate::html::html_body(&text);
     }
 
-    if let Some(k) = self.keep_element.as_ref() {
+    if let Some(k) = keep_element.as_ref() {
       match k.filter_description(&text) {
         Some(filtered) => {
           text = filtered;
@@ -117,6 +120,22 @@ impl FullTextFilter {
         }
       }
     }
+
+    text
+  }
+
+  async fn try_fetch_full_post(&self, post: &mut Post) -> Result<()> {
+    let link = post.link_or_err()?.to_owned();
+    let mut text = self.fetch_html(&link).await?;
+
+    // Optimization: the strip_post_content can be CPU intensive. Spawn the blocking
+    // task on a different CPU to improve parallelism.
+    let simplify = self.simplify;
+    let keep_element = Arc::new(self.keep_element.clone());
+    text = tokio::task::spawn_blocking(move || {
+      Self::strip_post_content(text, &link, simplify, keep_element)
+    })
+    .await?;
 
     let description = post.description_or_insert();
     if self.append_mode {
@@ -157,7 +176,7 @@ impl FullTextFilter {
       .collect::<Vec<_>>()
       .await
       .into_iter()
-      .collect::<Result<Vec<_>>>()
+      .collect()
   }
 }
 

--- a/src/filter/html.rs
+++ b/src/filter/html.rs
@@ -116,6 +116,7 @@ pub struct KeepElementConfig {
   selector: String,
 }
 
+#[derive(Clone)]
 pub struct KeepElement {
   selectors: Vec<Selector>,
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -85,6 +85,9 @@ pub enum Error {
   #[error("Config error {0:?}")]
   Config(#[from] ConfigError),
 
+  #[error("Tokio task join error {0}")]
+  Join(#[from] tokio::task::JoinError),
+
   #[error("{0}")]
   Message(String),
 }


### PR DESCRIPTION
I realized the post processing of the fetched html page is a bottleneck for full_text filter. After profiling, I found:

- The post processing step in dev mode can take 100ms-400ms.
- Most of the computation were hidden inside `tendril` and `html5ever` libraries, which is not easily optimized from this crate.
- Even worse, the post-processing for each feed item was not parallelized. So the latency add up.

So in this patch I moved the compute intensive part into separate tokio tasks so they can be computed at the same time.

For reference, before the change, the sample hackernews full text endpoint [1] takes around 9s to finish. With the request caching, it still takes around 4s. After the change, the uncached version takes 4s and cached version only take less than 1s (on my 8-core machine).

[1]:

``` yaml
  - path: /hackernews.xml
    source: https://news.ycombinator.com/rss
    filters:
      - full_text:
          simplify: true
          append_mode: true
```
