### PR TITLE
feat(inspector-ui): show config and feed error message

### DIFF
--- a/inspector/src/FeedInspector.js
+++ b/inspector/src/FeedInspector.js
@@ -40,9 +40,18 @@ export class FeedInspector {
     ]);
 
     const resp_json = await resp.json();
-    this.config = resp_json.root_config;
     this.config_error = resp_json.config_error;
+    this.config = resp_json.root_config;
     this.filter_schema = await filter_schema.json();
+
+    if (this.config_error) {
+      $("#config-error-message").innerText = this.config_error;
+      $("#config-error").classList.remove("hidden");
+      return;
+    } else {
+      $("#config-error").classList.add("hidden");
+      $("#config-error-message").innerText = "";
+    }
 
     if (!this.config) {
       console.error("Failed to load config");

--- a/inspector/src/FeedInspector.js
+++ b/inspector/src/FeedInspector.js
@@ -11,6 +11,8 @@ import "json-schema-view-js/src/style.less";
 export class FeedInspector {
   constructor() {
     this.config = null;
+    this.config_error = null;
+    this.feed_error = null;
     this.filter_schema = null;
     this.current_endpoint = null;
     this.current_preview = null;
@@ -37,7 +39,9 @@ export class FeedInspector {
       fetch("/_inspector/filter_schema?filters=all"),
     ]);
 
-    this.config = await resp.json();
+    const resp_json = await resp.json();
+    this.config = resp_json.root_config;
+    this.config_error = resp_json.config_error;
     this.filter_schema = await filter_schema.json();
 
     if (!this.config) {

--- a/inspector/src/FeedInspector.js
+++ b/inspector/src/FeedInspector.js
@@ -135,7 +135,7 @@ export class FeedInspector {
       sizes: [20, 80],
       snapOffset: 0,
       gutterSize: 3,
-      minSize: [300, 500],
+      dragInterval: 3,
     });
   }
 

--- a/inspector/src/FeedInspector.js
+++ b/inspector/src/FeedInspector.js
@@ -389,15 +389,33 @@ export class FeedInspector {
     const request_path = `${path}?${params}`;
     $("#fetch-status").innerText = `Fetching ${request_path}...`;
     const resp = await fetch(`${path}?${params}`);
-    const text = await resp.text();
+    let status_text = "";
 
-    $("#fetch-status").innerText = `Fetched ${request_path} in ${
-      performance.now() - time_start
-    }ms.`;
+    if (resp.status != 200) {
+      status_text = `Failed fetching ${request_path}`;
+      status_text += ` (status: ${resp.status} ${resp.statusText})`;
+      this.update_feed_error(await resp.text());
+    } else {
+      this.update_feed_error(null);
+      const text = await resp.text();
+      this.raw_feed_xml = text;
+      status_text = `Fetched ${request_path} `;
+      status_text += `(content-type: ${resp.headers.get("content-type")})`;
+    }
 
+    status_text += ` in ${performance.now() - time_start}ms.`;
+    $("#fetch-status").innerText = status_text;
     $("#feed-preview").classList.remove("loading");
+  }
 
-    this.raw_feed_xml = text;
+  update_feed_error(error) {
+    if (error) {
+      $("#feed-error").classList.remove("hidden");
+      $("#feed-error-message").innerText = error;
+    } else {
+      $("#feed-error-message").innerText = "";
+      $("#feed-error").classList.add("hidden");
+    }
   }
 
   feed_request_param() {

--- a/inspector/src/Filter.js
+++ b/inspector/src/Filter.js
@@ -86,6 +86,14 @@ export class Filter {
   render_js_config() {
     return highlight_js(this.config);
   }
+
+  render_modify_feed_config() {
+    return highlight_js(this.config);
+  }
+
+  render_modify_post_config() {
+    return highlight_js(this.config);
+  }
 }
 
 function highlight_json_value(value) {
@@ -100,5 +108,5 @@ function highlight_js(code) {
   const html = Prism.highlight(code, Prism.languages.javascript, "js");
   const code_node = elt("code", {}, []);
   code_node.innerHTML = html;
-  return elt("pre", {}, code_node);
+  return elt("pre", { class: "js-code" }, code_node);
 }

--- a/inspector/src/index.html
+++ b/inspector/src/index.html
@@ -77,6 +77,10 @@
             />
           </label>
         </div>
+        <div id="feed-error" class="hidden">
+          <h4>Error detected while processing feed</h4>
+          <p id="feed-error-message"></p>
+        </div>
         <div id="feed-preview">
           <header id="view-mode-selector">
             <div id="rendered-radio" class="radio-button">

--- a/inspector/src/index.html
+++ b/inspector/src/index.html
@@ -14,13 +14,16 @@
     <div class="container">
       <div id="sidebar-panel">
         <div class="button" id="reload-config-button">Reload Config</div>
+        <div id="config-error" class="hidden">
+          <h4>Error detected in config</h4>
+          <p id="config-error-message"></p>
+        </div>
         <div id="sidebar-endpoints">
           <div class="sidebar-header">
             <h4>Endpoints</h4>
           </div>
           <ul id="endpoint-list"></ul>
         </div>
-
         <div id="sidebar-endpoint" class="hidden">
           <div class="sidebar-header">
             <div class="button" id="back-to-endpoints">Back</div>

--- a/inspector/src/style.css
+++ b/inspector/src/style.css
@@ -37,6 +37,25 @@ table th {
   border-radius: 10px;
 }
 
+.info-box {
+  padding: 0.5rem 0.5rem;
+  border: 1px solid #ddd;
+  border-radius: 0.3rem;
+
+  > header {
+    background-color: white;
+    width: fit-content;
+    padding: 0 0.3rem;
+    position: relative;
+    /* half (padding-y + border) + half font height */
+    margin-top: -1rem;
+    font-size: 0.8em;
+  }
+
+  > content {
+  }
+}
+
 #sidebar-panel {
   display: flex;
   flex-direction: column;
@@ -60,6 +79,14 @@ table th {
   }
 }
 
+#config-error {
+  #config-error-message {
+    padding: 0.5rem;
+    color: #721c24;
+    background-color: #f8d7da;
+  }
+}
+
 #reload-config-button {
   text-align: center;
   margin-bottom: 0.5rem;
@@ -75,25 +102,6 @@ table th {
 
   &:hover {
     background-color: #f4f4f4;
-  }
-}
-
-.info-box {
-  padding: 0.5rem 0.5rem;
-  border: 1px solid #ddd;
-  border-radius: 0.3rem;
-
-  > header {
-    background-color: white;
-    width: fit-content;
-    padding: 0 0.3rem;
-    position: relative;
-    /* half (padding-y + border) + half font height */
-    margin-top: -1rem;
-    font-size: 0.8em;
-  }
-
-  > content {
   }
 }
 

--- a/inspector/src/style.css
+++ b/inspector/src/style.css
@@ -207,8 +207,11 @@ ul#filter-list {
       pre {
         margin: 0;
       }
-      code {
+      pre.js-code {
+        /* allow wrapping in js code */
+        white-space: normal;
       }
+
       ul {
         list-style: square;
         padding-left: 1.6rem;

--- a/inspector/src/style.css
+++ b/inspector/src/style.css
@@ -134,10 +134,11 @@ table th {
 
   #source-info {
     margin: 1rem 0;
-    overflow-x: scroll;
 
     content {
       position: relative;
+      overflow-x: scroll;
+      display: block;
 
       .format-tag {
         position: absolute;

--- a/inspector/src/style.css
+++ b/inspector/src/style.css
@@ -56,6 +56,11 @@ table th {
   }
 }
 
+/* section heading */
+h4 {
+  margin: 0.5rem 0;
+}
+
 #sidebar-panel {
   display: flex;
   flex-direction: column;
@@ -72,18 +77,17 @@ table th {
     margin-top: 0;
     margin-bottom: 0;
   }
-
-  h4 {
-    margin: 0.5rem 0;
-    padding-bottom: 0.5rem;
-  }
 }
 
+#feed-error,
 #config-error {
-  #config-error-message {
+  p {
     padding: 0.5rem;
     color: #721c24;
     background-color: #f8d7da;
+    margin-top: 0;
+    display: block;
+    border-radius: 0.3rem;
   }
 }
 
@@ -280,6 +284,7 @@ ul#filter-list {
   flex-direction: column;
   place-content: flex-start;
   gap: 0.3rem;
+  margin: 0;
 
   .endpoint {
     padding: 0.3rem;
@@ -356,20 +361,13 @@ ul#filter-list {
 #feed-error {
   flex: 1;
 
+  /* if there is a feed error, do not show feed preview */
   & + #feed-preview {
     display: none;
   }
 
   &.hidden + #feed-preview {
     display: block;
-  }
-
-  #feed-error-message {
-    padding: 0.5rem;
-    width: 100%;
-    margin-bottom: auto;
-    color: #721c24;
-    background-color: #f8d7da;
   }
 }
 

--- a/inspector/src/style.css
+++ b/inspector/src/style.css
@@ -287,11 +287,12 @@ ul#filter-list {
       display: flex;
       justify-content: space-between;
       align-items: center;
+      flex-wrap: wrap;
 
       .endpoint-path {
         font-size: 1.2em;
         margin: 0;
-        flex: 1;
+        margin-right: auto;
         cursor: pointer;
 
         &:hover {

--- a/inspector/src/style.css
+++ b/inspector/src/style.css
@@ -406,10 +406,11 @@ ul#filter-list {
     padding: 0.5rem;
     position: absolute;
     box-shadow: 0 1px 2px #ddd;
-    opacity: 0.5;
+    opacity: 0.3;
+    transition: all 0.1s ease-in-out;
 
     &:hover {
-      opacity: 1;
+      opacity: 0.9;
     }
   }
 }

--- a/inspector/src/style.css
+++ b/inspector/src/style.css
@@ -110,7 +110,7 @@ table th {
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    flex-wrap: nowrap;
+    flex-wrap: wrap;
     margin-bottom: 0.5rem;
 
     h4 {
@@ -120,7 +120,7 @@ table th {
 
     #endpoint-name {
       font-family: monospace;
-      flex-grow: 1;
+      flex: 1;
       font-size: 1.2em;
     }
   }

--- a/inspector/src/style.css
+++ b/inspector/src/style.css
@@ -134,6 +134,7 @@ table th {
 
   #source-info {
     margin: 1rem 0;
+    overflow-x: scroll;
 
     content {
       position: relative;

--- a/inspector/src/style.css
+++ b/inspector/src/style.css
@@ -350,6 +350,26 @@ ul#filter-list {
   }
 }
 
+#feed-error {
+  flex: 1;
+
+  & + #feed-preview {
+    display: none;
+  }
+
+  &.hidden + #feed-preview {
+    display: block;
+  }
+
+  #feed-error-message {
+    padding: 0.5rem;
+    width: 100%;
+    margin-bottom: auto;
+    color: #721c24;
+    background-color: #f8d7da;
+  }
+}
+
 #feed-preview {
   /* enable scrolling */
   width: 100%;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -68,15 +68,15 @@ impl TestConfig {
 #[derive(
   JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
 )]
-pub struct FeedDefinition {
+pub struct RootConfig {
   pub endpoints: Vec<EndpointConfig>,
 }
 
-impl FeedDefinition {
+impl RootConfig {
   pub fn load_from_file(path: &Path) -> Result<Self, ConfigError> {
     let f = std::fs::File::open(path)?;
-    let feed_definition: Self = serde_yaml::from_reader(f)?;
-    Ok(feed_definition)
+    let root_config: Self = serde_yaml::from_reader(f)?;
+    Ok(root_config)
   }
 
   fn get_endpoint(&self, endpoint: &str) -> Option<EndpointConfig> {
@@ -95,7 +95,7 @@ impl Cli {
         server_config.run(&self.config).await
       }
       SubCommand::Test(test_config) => {
-        let feed_defn = FeedDefinition::load_from_file(&self.config)?;
+        let feed_defn = RootConfig::load_from_file(&self.config)?;
         test_endpoint(feed_defn, &test_config).await;
         Ok(())
       }
@@ -103,7 +103,7 @@ impl Cli {
   }
 }
 
-async fn test_endpoint(feed_defn: FeedDefinition, test_config: &TestConfig) {
+async fn test_endpoint(feed_defn: RootConfig, test_config: &TestConfig) {
   let Some(endpoint_conf) = feed_defn.get_endpoint(&test_config.endpoint)
   else {
     let endpoints: Vec<_> =

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 // #[cfg(feature = "inspector-ui")]
-// pub use crate::cli::FeedDefinition;
+// pub use crate::cli::RootConfig;
 // pub use crate::client::ClientConfig;
 // pub use crate::filter::FilterConfig;
 // pub use crate::server::endpoint::{EndpointConfig, EndpointServiceConfig};

--- a/src/server.rs
+++ b/src/server.rs
@@ -13,7 +13,7 @@ use tower_http::compression::CompressionLayer;
 use tracing::{error, info, warn};
 
 use crate::{
-  cli::FeedDefinition,
+  cli::RootConfig,
   util::{ConfigError, Result},
 };
 pub use endpoint::{EndpointConfig, EndpointOutcome, EndpointParam};
@@ -54,13 +54,13 @@ impl ServerConfig {
 
   #[allow(unused)]
   pub async fn run_without_fs_watcher(self, config_path: &Path) -> Result<()> {
-    let config = FeedDefinition::load_from_file(config_path)?;
+    let config = RootConfig::load_from_file(config_path)?;
     let feed_service = FeedService::try_from(config).await?;
     self.serve(feed_service).await
   }
 
   pub async fn run_with_fs_watcher(self, config_path: &Path) -> Result<()> {
-    let config = FeedDefinition::load_from_file(config_path)?;
+    let config = RootConfig::load_from_file(config_path)?;
     let feed_service = FeedService::try_from(config).await?;
 
     // watcher must not be dropped until the end of the function

--- a/src/server/feed_service.rs
+++ b/src/server/feed_service.rs
@@ -47,12 +47,12 @@ impl FeedService {
     })
   }
 
-  pub async fn error<R>(&self, callback: impl FnOnce(&ConfigError) -> R) -> R {
+  pub async fn error<R>(
+    &self,
+    callback: impl FnOnce(&ConfigError) -> R,
+  ) -> Option<R> {
     let inner = self.inner.read().await;
-    match &inner.config_error {
-      Some(e) => callback(e),
-      None => panic!("no error"),
-    }
+    inner.config_error.as_ref().map(callback)
   }
 
   pub async fn root_config(&self) -> Arc<RootConfig> {

--- a/src/server/inspector.rs
+++ b/src/server/inspector.rs
@@ -71,7 +71,7 @@ async fn static_handler(uri: Uri) -> impl IntoResponse {
 async fn config_handler(
   Extension(feed_service): Extension<FeedService>,
 ) -> impl IntoResponse {
-  Json(feed_service.feed_definition().await)
+  Json(feed_service.root_config().await)
 }
 
 #[derive(serde::Deserialize)]

--- a/src/server/inspector.rs
+++ b/src/server/inspector.rs
@@ -6,6 +6,7 @@ use axum::Json;
 use axum::{routing::get, Extension, Router};
 use http::{StatusCode, Uri};
 use schemars::schema::RootSchema;
+use serde_json::json;
 
 use crate::filter::FilterConfig;
 use crate::util::Error;
@@ -71,7 +72,11 @@ async fn static_handler(uri: Uri) -> impl IntoResponse {
 async fn config_handler(
   Extension(feed_service): Extension<FeedService>,
 ) -> impl IntoResponse {
-  Json(feed_service.root_config().await)
+  let json = json!({
+    "config_error": feed_service.error(|e| e.to_string()).await,
+    "root_config": feed_service.root_config().await,
+  });
+  Json(json)
 }
 
 #[derive(serde::Deserialize)]


### PR DESCRIPTION
This patch improves the display of feed error and adds the ability to show config error.

Screenshot showing both the config error and the feed error:
![image](https://github.com/shouya/rss-funnel/assets/526598/9801751b-7d09-47bb-9052-b9d77eb3b874)

Fixes https://github.com/shouya/rss-funnel/issues/39.