### PR TITLE
fix(endpoint): handle non-utf8 feeds correctly

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -160,14 +160,13 @@ impl Client {
       .error_for_status()?;
 
     let content_type = resp.content_type().map(|x| x.essence_str().to_owned());
-    let content = resp.text()?;
 
     let feed = match content_type.as_deref() {
-      Some("text/html") => Feed::from_html_content(&content, source)?,
-      Some("application/rss+xml") => Feed::from_rss_content(&content)?,
-      Some("application/atom+xml") => Feed::from_atom_content(&content)?,
+      Some("text/html") => Feed::from_html_content(&resp.text()?, source)?,
+      Some("application/rss+xml") => Feed::from_rss_content(resp.body())?,
+      Some("application/atom+xml") => Feed::from_atom_content(resp.body())?,
       Some("application/xml") | Some("text/xml") => {
-        Feed::from_xml_content(&content)?
+        Feed::from_xml_content(resp.body())?
       }
       x => todo!("{:?}", x),
     };

--- a/src/client.rs
+++ b/src/client.rs
@@ -9,7 +9,7 @@ use url::Url;
 
 use crate::{
   feed::Feed,
-  util::{ConfigError, Result},
+  util::{ConfigError, Error, Result},
 };
 
 use self::cache::{Response, ResponseCache};
@@ -168,7 +168,8 @@ impl Client {
       Some("application/xml") | Some("text/xml") => {
         Feed::from_xml_content(resp.body())?
       }
-      x => todo!("{:?}", x),
+      Some(format) => Err(Error::UnsupportedFeedFormat(format.into()))?,
+      None => Feed::from_xml_content(resp.body())?,
     };
 
     Ok(feed)

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -38,19 +38,19 @@ impl Feed {
     }
   }
 
-  pub fn from_rss_content(content: &str) -> Result<Self> {
+  pub fn from_rss_content(content: &[u8]) -> Result<Self> {
     let cursor = std::io::Cursor::new(content);
     let channel = rss::Channel::read_from(cursor)?;
     Ok(Feed::Rss(channel))
   }
 
-  pub fn from_atom_content(content: &str) -> Result<Self> {
+  pub fn from_atom_content(content: &[u8]) -> Result<Self> {
     let cursor = std::io::Cursor::new(content);
     let feed = atom_syndication::Feed::read_from(cursor)?;
     Ok(Feed::Atom(feed))
   }
 
-  pub fn from_xml_content(content: &str) -> Result<Self> {
+  pub fn from_xml_content(content: &[u8]) -> Result<Self> {
     Feed::from_rss_content(content)
       .or_else(|_| Feed::from_atom_content(content))
   }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -78,12 +78,8 @@ pub async fn fetch_endpoint(config: &str, query: &str) -> Feed {
   let body = axum::body::to_bytes(http_resp.into_body(), usize::MAX)
     .await
     .expect("failed to read body");
-  let body =
-    std::str::from_utf8(&body).expect("failed to decode body as utf-8");
 
-  Feed::from_rss_content(body)
-    .or_else(|_| Feed::from_atom_content(body))
-    .expect("failed to parse feed")
+  Feed::from_xml_content(&body).expect("failed to parse feed")
 }
 
 fn dummy_client() -> Client {

--- a/src/util.rs
+++ b/src/util.rs
@@ -91,6 +91,9 @@ pub enum Error {
   #[error("Endpoint not found {0}")]
   EndpointNotFound(String),
 
+  #[error("Unsupported feed format {0}")]
+  UnsupportedFeedFormat(String),
+
   #[error("{0}")]
   Message(String),
 }


### PR DESCRIPTION
Fixes https://github.com/shouya/rss-funnel/issues/66.

Also, unknown feed types now raise an error than panicking.