### PR TITLE
feat(js): implement fetch api for js runtime

### DIFF
--- a/inspector/src/index.html
+++ b/inspector/src/index.html
@@ -16,7 +16,7 @@
         <div class="button" id="reload-config-button">Reload Config</div>
         <div id="config-error" class="hidden">
           <h4>Error detected in config</h4>
-          <p id="config-error-message"></p>
+          <pre id="config-error-message"></p>
         </div>
         <div id="sidebar-endpoints">
           <div class="sidebar-header">
@@ -79,7 +79,7 @@
         </div>
         <div id="feed-error" class="hidden">
           <h4>Error detected while processing feed</h4>
-          <p id="feed-error-message"></p>
+          <pre id="feed-error-message"></p>
         </div>
         <div id="feed-preview">
           <header id="view-mode-selector">

--- a/inspector/src/style.css
+++ b/inspector/src/style.css
@@ -81,13 +81,15 @@ h4 {
 
 #feed-error,
 #config-error {
-  p {
+  pre {
     padding: 0.5rem;
     color: #721c24;
     background-color: #f8d7da;
     margin-top: 0;
     display: block;
     border-radius: 0.3rem;
+    white-space: pre-wrap;
+    word-wrap: break-word;
   }
 }
 

--- a/src/filter/js.rs
+++ b/src/filter/js.rs
@@ -52,11 +52,27 @@ pub struct JsFilter {
 
 const MODIFY_POSTS_CODE: &str = r#"
   async function modify_posts(feed) {
-    const items = feed.items || feed.entries || [];
+    const posts = feed.items || feed.entries || [];
     if (modify_post[Symbol.toStringTag] === 'AsyncFunction') {
-      return await Promise.all(items.map(post => modify_post(feed, post)));
+      const modify_post_with_exception_handled = async function(post) {
+        try {
+          return await modify_post(feed, post);
+        } catch (e) {
+          console.error(e);
+          return post;
+        }
+      };
+      return await Promise.all(posts.map(modify_post_with_exception_handled));
     } else {
-      return items.map(post => modify_post(feed, post));
+      const modify_post_with_exception_handled = function(post) {
+        try {
+          return modify_post(feed, post);
+        } catch (e) {
+          console.error(e);
+          return post;
+        }
+      };
+      return posts.map(modify_post_with_exception_handled);
     }
   }
 "#;

--- a/src/filter/js.rs
+++ b/src/filter/js.rs
@@ -67,7 +67,7 @@ impl FeedFilterConfig for ModifyPostConfig {
 
   async fn build(self) -> Result<Self::Filter, ConfigError> {
     let code = format!(
-      "function modify_post(feed, post) {{ {}; return post; }}",
+      "async function modify_post(feed, post) {{ {}; return post; }}",
       self.code
     );
     JsConfig { code }.build().await

--- a/src/js.rs
+++ b/src/js.rs
@@ -342,3 +342,34 @@ impl From<&rquickjs::Exception<'_>> for Exception {
     }
   }
 }
+
+impl std::fmt::Display for Exception {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(
+      f,
+      "{}\n{}:{}:{}\n",
+      self.message.as_deref().unwrap_or(""),
+      self.file.as_deref().unwrap_or(""),
+      self.line.unwrap_or(0),
+      self.column.unwrap_or(0),
+    )?;
+
+    match (self.source.as_deref(), self.line, self.column) {
+      (Some(source), Some(line), Some(column)) => {
+        dbg!(source);
+        for (i, text) in source.lines().enumerate() {
+          writeln!(f, "{}", text)?;
+          if line == (i + 1) as i32 {
+            for _ in 0..column {
+              f.write_str("-")?;
+            }
+            f.write_str("^\n")?;
+          }
+        }
+      }
+      _ => {}
+    };
+
+    Ok(())
+  }
+}

--- a/src/js.rs
+++ b/src/js.rs
@@ -1,5 +1,6 @@
 mod builtin;
 mod dom;
+mod fetch;
 
 use std::fs;
 use std::path::PathBuf;
@@ -19,6 +20,7 @@ pub struct Runtime {
   context: rquickjs::Context,
 }
 
+#[derive(Default, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct AsJson<T>(pub T);
 
 impl<'js, T> IntoJs<'js> for AsJson<T>

--- a/src/js/builtin.rs
+++ b/src/js/builtin.rs
@@ -41,6 +41,16 @@ impl Console {
     println!("[console.log] {}", msg);
     Ok(())
   }
+
+  fn error(&self, value: rquickjs::Value<'_>) -> Result<(), rquickjs::Error> {
+    let msg = match value.try_into_string() {
+      Ok(s) => s.to_string()?,
+      Err(v) => format!("[{}] {:?}", v.type_name(), v),
+    };
+
+    eprintln!("[console.error] {}", msg);
+    Ok(())
+  }
 }
 
 #[derive(Trace)]

--- a/src/js/builtin.rs
+++ b/src/js/builtin.rs
@@ -1,6 +1,11 @@
-use rquickjs::{class::Trace, Class, Ctx};
+use rquickjs::{
+  class::Trace,
+  function::{Async, Func},
+  Class, Ctx,
+};
 
 use super::dom::{Node, DOM};
+use super::fetch::fetch;
 use crate::util::Result;
 
 pub(super) fn register_builtin(ctx: &Ctx) -> Result<(), rquickjs::Error> {
@@ -14,6 +19,9 @@ pub(super) fn register_builtin(ctx: &Ctx) -> Result<(), rquickjs::Error> {
   ctx
     .globals()
     .set("util", Class::instance(ctx.clone(), Util {})?)?;
+
+  let fetch_fn = Func::new(Async(fetch));
+  ctx.globals().set("fetch", fetch_fn)?;
 
   Ok(())
 }

--- a/src/js/dom.rs
+++ b/src/js/dom.rs
@@ -8,7 +8,7 @@ use rquickjs::{
 };
 use scraper::ElementRef;
 
-use crate::util::Result;
+use crate::{html::fragment_root_node_id, util::Result};
 
 #[rquickjs::class]
 #[derive(Clone)]
@@ -537,19 +537,4 @@ mod test {
     let rt = Runtime::new().await.unwrap();
     rt.eval(code).await.unwrap()
   }
-}
-
-fn fragment_root_node_id(mut node: NodeRef<'_, scraper::Node>) -> NodeId {
-  let val = node.value();
-  if val.is_fragment() || val.is_document() {
-    node = node.first_child().unwrap();
-    return fragment_root_node_id(node);
-  }
-
-  if val.as_element().is_some_and(|e| e.name() == "html") {
-    node = node.first_child().unwrap();
-    return fragment_root_node_id(node);
-  }
-
-  node.id()
 }

--- a/src/js/fetch.rs
+++ b/src/js/fetch.rs
@@ -1,0 +1,91 @@
+use std::collections::HashMap;
+
+use rquickjs::{class::Trace, function::Opt, Ctx, Exception};
+use serde::{Deserialize, Serialize};
+
+use super::AsJson;
+
+#[derive(Deserialize)]
+#[allow(clippy::upper_case_acronyms)]
+enum Method {
+  GET,
+  POST,
+  PUT,
+  DELETE,
+}
+
+impl From<Method> for reqwest::Method {
+  fn from(method: Method) -> Self {
+    match method {
+      Method::GET => reqwest::Method::GET,
+      Method::POST => reqwest::Method::POST,
+      Method::PUT => reqwest::Method::PUT,
+      Method::DELETE => reqwest::Method::DELETE,
+    }
+  }
+}
+
+#[derive(Deserialize)]
+pub(super) struct RequestParams {
+  method: Method,
+  headers: HashMap<String, String>,
+  body: Option<String>,
+}
+
+impl Default for RequestParams {
+  fn default() -> Self {
+    Self {
+      method: Method::GET,
+      headers: HashMap::new(),
+      body: None,
+    }
+  }
+}
+
+#[derive(Trace, Serialize)]
+#[rquickjs::class]
+pub(super) struct Response {
+  status: u16,
+  headers: HashMap<String, String>,
+  body: String,
+}
+
+pub(super) async fn fetch(
+  ctx: Ctx<'_>,
+  url: String,
+  params: Opt<AsJson<RequestParams>>,
+) -> Result<Response, rquickjs::Error> {
+  let params = params.into_inner().map(|x| x.0).unwrap_or_default();
+  let client = reqwest::Client::new();
+  let mut builder = client.request(params.method.into(), url);
+
+  for (k, v) in params.headers {
+    builder = builder.header(k, v);
+  }
+
+  if let Some(body) = params.body {
+    builder = builder.body(body);
+  }
+
+  let resp = builder
+    .send()
+    .await
+    .map_err(|e| Exception::throw_message(&ctx, &e.to_string()))?;
+  let status = resp.status().as_u16();
+  let mut headers = HashMap::new();
+
+  for (k, v) in resp.headers() {
+    headers.insert(k.as_str().to_string(), v.to_str().unwrap().to_string());
+  }
+
+  let body = resp
+    .text()
+    .await
+    .map_err(|e| Exception::throw_message(&ctx, &e.to_string()))?;
+
+  Ok(Response {
+    status,
+    headers,
+    body,
+  })
+}

--- a/src/js/fetch.rs
+++ b/src/js/fetch.rs
@@ -83,8 +83,6 @@ pub(super) async fn fetch(
     .await
     .map_err(|e| Exception::throw_message(&ctx, &e.to_string()))?;
 
-  dbg!(&body);
-
   Ok(Response {
     status,
     headers,

--- a/src/js/fetch.rs
+++ b/src/js/fetch.rs
@@ -105,12 +105,14 @@ mod tests {
       source: fixture:///minimal_rss_20.xml
       filters:
         - modify_post: |
-            let x = fetch("http://example.com");
-            console.log(x);
+            let x = await fetch("http://example.com");
+            console.log(JSON.stringify(x));
             post.description = x.body;
     "#;
 
     let _feed = fetch_endpoint(config, "").await;
+
+    assert!(false);
 
     Ok(())
   }

--- a/src/js/fetch.rs
+++ b/src/js/fetch.rs
@@ -157,8 +157,6 @@ mod tests {
 
     let _feed = fetch_endpoint(config, "").await;
 
-    assert!(false);
-
     Ok(())
   }
 }

--- a/src/js/fetch.rs
+++ b/src/js/fetch.rs
@@ -42,7 +42,7 @@ impl Default for RequestParams {
   }
 }
 
-#[derive(Trace, Serialize)]
+#[derive(Trace, Serialize, Debug)]
 #[rquickjs::class]
 pub(super) struct Response {
   status: u16,
@@ -83,9 +83,35 @@ pub(super) async fn fetch(
     .await
     .map_err(|e| Exception::throw_message(&ctx, &e.to_string()))?;
 
+  dbg!(&body);
+
   Ok(Response {
     status,
     headers,
     body,
   })
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::test_utils::fetch_endpoint;
+  use crate::util::Result;
+
+  #[tokio::test]
+  async fn test_fetch() -> Result<()> {
+    let config = r#"
+      !endpoint
+      path: /fetch
+      source: fixture:///minimal_rss_20.xml
+      filters:
+        - modify_post: |
+            let x = fetch("http://example.com");
+            console.log(x);
+            post.description = x.body;
+    "#;
+
+    let _feed = fetch_endpoint(config, "").await;
+
+    Ok(())
+  }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -10,8 +10,11 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Debug, thiserror::Error)]
 pub enum JsError {
-  #[error("Js exception {0}")]
-  Exception(String),
+  #[error("Js error: {0:?}")]
+  Message(String),
+
+  #[error("Js exception: {0:?}")]
+  Exception(crate::js::Exception),
 
   #[error("QuickJS error {0:?}")]
   Error(#[from] rquickjs::Error),

--- a/src/util.rs
+++ b/src/util.rs
@@ -10,37 +10,37 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Debug, thiserror::Error)]
 pub enum JsError {
-  #[error("Js error: {0:?}")]
+  #[error("{0}")]
   Message(String),
 
-  #[error("Js exception: {0:?}")]
+  #[error("Exception: {0}")]
   Exception(crate::js::Exception),
 
-  #[error("QuickJS error {0:?}")]
+  #[error("{0}")]
   Error(#[from] rquickjs::Error),
 }
 
 #[derive(Debug, thiserror::Error)]
 pub enum ConfigError {
-  #[error("Bad selector")]
+  #[error("Bad selector: {0}")]
   BadSelector(String),
 
-  #[error("YAML parse error")]
+  #[error("YAML parse error: {0}")]
   Yaml(#[from] serde_yaml::Error),
 
-  #[error("Regex error")]
+  #[error("Regex error: {0}")]
   Regex(#[from] regex::Error),
 
   #[error("Invalid URL {0}")]
   InvalidUrl(#[from] url::ParseError),
 
-  #[error("IO error")]
+  #[error("IO error: {0}")]
   Io(#[from] std::io::Error),
 
-  #[error("Reqwest client error {0:?}")]
+  #[error("Reqwest client error: {0}")]
   Reqwest(#[from] reqwest::Error),
 
-  #[error("Js runtime initialization error {0:?}")]
+  #[error("Js runtime initialization error: {0}")]
   Js(#[from] JsError),
 
   #[error("{0}")]
@@ -49,52 +49,52 @@ pub enum ConfigError {
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-  #[error("IO error")]
+  #[error("IO error: {0}")]
   Io(#[from] std::io::Error),
 
-  #[error("HTTP error")]
+  #[error("HTTP error: {0}")]
   Http(#[from] http::Error),
 
-  #[error("Axum error")]
+  #[error("Axum error: {0}")]
   Axum(#[from] axum::Error),
 
-  #[error("RSS feed error")]
+  #[error("RSS feed error: {0}")]
   Rss(#[from] rss::Error),
 
-  #[error("Atom feed error")]
+  #[error("Atom feed error: {0}")]
   Atom(#[from] atom_syndication::Error),
 
-  #[error("Invalid URL {0}")]
+  #[error("Invalid URL: {0}")]
   InvalidUrl(#[from] url::ParseError),
 
-  #[error("Feed parsing error {0:?}")]
+  #[error("Feed parsing error: {0}")]
   FeedParse(&'static str),
 
-  #[error("Feed merge error {0:?}")]
+  #[error("Feed merge error: {0}")]
   FeedMerge(&'static str),
 
-  #[error("Reqwest client error {0:?}")]
+  #[error("Reqwest client error: {0}")]
   Reqwest(#[from] reqwest::Error),
 
-  #[error("HTTP status error {0:?} (url: {1})")]
+  #[error("HTTP status error {0} (url: {1})")]
   HttpStatus(reqwest::StatusCode, Url),
 
-  #[error("Js runtime error {0:?}")]
+  #[error("Js runtime error: {0}")]
   Js(#[from] JsError),
 
-  #[error("Failed to extract webpage {0:?}")]
+  #[error("Failed to extract webpage: {0}")]
   Readability(#[from] readability::error::Error),
 
-  #[error("Config error {0:?}")]
+  #[error("Config error: {0}")]
   Config(#[from] ConfigError),
 
-  #[error("Tokio task join error {0}")]
+  #[error("Tokio task join error: {0}")]
   Join(#[from] tokio::task::JoinError),
 
-  #[error("Endpoint not found {0}")]
+  #[error("Endpoint not found: {0}")]
   EndpointNotFound(String),
 
-  #[error("Unsupported feed format {0}")]
+  #[error("Unsupported feed format: {0}")]
   UnsupportedFeedFormat(String),
 
   #[error("{0}")]


### PR DESCRIPTION
This PR is to implement a simple fetch api for the JS runtime. It enables the user to request data from servers within any JavaScript code.

Here's the API:

``` typescript
type RequestParam = {
  method: "GET" | "POST" | "PUT" | "DELETE",
  headers: { [key: string]: string },
  body: string?
}

fetch(url: string, params?: RequestParam): Promise<Response>;

class Response {
  status: number,
  headers: { [key: string]: string },
  body: string | null

  json(): Object
}
```

Here's a sample endpoint that returns de-clickbait-ed youtube feed using [DeArrow](https://github.com/ajayyy/DeArrow) service:

```yaml
  - path: /kurtzgesagt-dearrow.xml
    source: https://www.youtube.com/feeds/videos.xml?channel_id=UCsXVk37bltHxD1rDPwtNM8Q
    filters:
      - modify_post: |
          const video_id = post.id.split(':').pop();
          let resp = await fetch(`https://sponsor.ajay.app/api/branding?videoID=${video_id}`);
          if (resp.status == 200) {
            let [title] = resp.json().titles;
            post.title.value = title.title;
          }
          let thumbnail = post.extensions.media.group.filter(g => g.name == 'media:group')[0].children.thumbnail[0];
          thumbnail.attrs.url = `https://dearrow-thumb.ajay.app/api/v1/getThumbnail?videoID=${video_id}`;
```

(Fixes https://github.com/shouya/rss-funnel/issues/41)

A few more subtle changes:

- errors are handled and displayed more nicely: instead of throwing the error's internal struct at the user, now we display the error message instead
- js syntax errors will now show the code context
- exceptions raised within `modify_post` are now reported and ignored, so they won't break the feed
- both `modify_post` and `modify_feed` can be defined as async functions
- the `modify_post` function are now called concurrently for each post, this is especially useful when the function contains long-time async operations.