### PR TITLE
feat(inspector-ui): authentication support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,6 +223,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-extra"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "895ff42f72016617773af68fb90da2a9677d89c62338ec09162d4909d86fdd8f"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "cookie",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "serde",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "axum-macros"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,6 +409,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cd91cf61412820176e137621345ee43b3f4423e589e7ae4e50d601d93e35ef8"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,6 +526,15 @@ name = "data-encoding"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "derive_builder"
@@ -1402,6 +1444,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-traits"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1587,6 +1635,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1892,6 +1946,7 @@ dependencies = [
  "async-trait",
  "atom_syndication",
  "axum",
+ "axum-extra",
  "axum-macros",
  "chrono",
  "clap",
@@ -1909,6 +1964,7 @@ dependencies = [
  "mime",
  "notify",
  "paste",
+ "rand",
  "readability",
  "regex",
  "reqwest",
@@ -2382,6 +2438,37 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ chrono = "0.4.34"
 # webui (inspector) support
 rust-embed = { version = "8.3.0", features = ["include-exclude"], optional = true }
 schemars = { git = "https://github.com/shouya/schemars", features = ["url", "preserve_order"] }
+rand = "0.8.5" # for generating session_id
 
 # HTML manipulation in the feeds
 scraper = "0.19.0"
@@ -75,6 +76,7 @@ regex = "1.10.3"
 # Logging
 tracing = { version = "0.1.40"}
 tracing-subscriber = "0.3.18"
+axum-extra = { version = "0.9.2", features = ["cookie"] }
 
 [patch.crates-io]
 ego-tree = { git = "https://github.com/shouya/ego-tree.git" }

--- a/inspector/package.json
+++ b/inspector/package.json
@@ -7,7 +7,7 @@
     "parcel": "^2.11.0",
     "process": "^0.11.10"
   },
-  "source": "src/index.html",
+  "source": ["src/index.html", "src/login.html"],
   "targets": {
     "default": {
       "distDir": "./dist",

--- a/inspector/src/FeedInspector.js
+++ b/inspector/src/FeedInspector.js
@@ -61,6 +61,12 @@ export class FeedInspector {
       return;
     }
 
+    if (this.config.auth) {
+      $("#logout-button").classList.remove("hidden");
+    } else {
+      $("#logout-button").classList.add("hidden");
+    }
+
     if (!this.current_endpoint) {
       await this.load_endpoints();
       await this.reset_main_ui();

--- a/inspector/src/index.html
+++ b/inspector/src/index.html
@@ -13,7 +13,10 @@
   <body>
     <div class="container">
       <div id="sidebar-panel">
-        <div class="button" id="reload-config-button">Reload Config</div>
+        <div id="control-buttons">
+          <div class="button" id="reload-config-button">Reload Config</div>
+          <a class="button hidden" id="logout-button" href="/logout">Logout</a>
+        </div>
         <div id="config-error" class="hidden">
           <h4>Error detected in config</h4>
           <pre id="config-error-message"></p>

--- a/inspector/src/login.html
+++ b/inspector/src/login.html
@@ -1,0 +1,44 @@
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>RSS Funnel Inspector - Login</title>
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href='data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="-45 -50 140 140"%3E%3Ccircle cx="306.7" cy="343.7" r="11.4" fill="%23ff7b00" transform="translate(-282 -331)"/%3E%3Cpath fill="none" stroke="%23ff7b00" stroke-width="15" d="M-3 16a29 29 0 1 1 56 0"/%3E%3Cpath fill="none" stroke="%23ff7b00" stroke-width="15" d="M-23 18a49 49 0 1 1 96-1"/%3E%3Cpath fill="%23ff7b00" d="m-24 29 98-1-1 10-40 28 1 19H17l1-20-42-27z"/%3E%3C/svg%3E%0A'
+    />
+    <style>
+      form {
+        display: flex;
+        flex-direction: column;
+        width: 200px;
+        gap: 0.5rem;
+      }
+
+      p#message {
+        color: red;
+      }
+    </style>
+  </head>
+  <body>
+    <div>
+      <h1>RSS Funnel Inspector</h1>
+      <p id="message"></p>
+      <form action="/login" method="post">
+        <input type="text" name="username" placeholder="Username" />
+        <input type="password" name="password" placeholder="Password" />
+        <input type="submit" value="Login" />
+      </form>
+      <script>
+        const message = document.getElementById("message");
+        const search = window.location.search;
+        if (search.includes("bad_auth")) {
+          message.textContent = "Invalid username or password";
+        } else if (search.includes("logged_out")) {
+          message.textContent = "You have been logged out";
+        } else if (search.includes("requires_login")) {
+          message.textContent = "You must be logged in to access that page";
+        }
+      </script>
+  </body>
+</html>

--- a/inspector/src/login.html
+++ b/inspector/src/login.html
@@ -8,11 +8,27 @@
       href='data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="-45 -50 140 140"%3E%3Ccircle cx="306.7" cy="343.7" r="11.4" fill="%23ff7b00" transform="translate(-282 -331)"/%3E%3Cpath fill="none" stroke="%23ff7b00" stroke-width="15" d="M-3 16a29 29 0 1 1 56 0"/%3E%3Cpath fill="none" stroke="%23ff7b00" stroke-width="15" d="M-23 18a49 49 0 1 1 96-1"/%3E%3Cpath fill="%23ff7b00" d="m-24 29 98-1-1 10-40 28 1 19H17l1-20-42-27z"/%3E%3C/svg%3E%0A'
     />
     <style>
+      h2 {
+        margin-bottom: 0.5rem;
+      }
+
+      body {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+      }
+
       form {
+        margin-top: 15px;
+        margin-bottom: 20px;
         display: flex;
         flex-direction: column;
         width: 200px;
         gap: 0.5rem;
+      }
+
+      .hidden {
+        display: none;
       }
 
       p#message {
@@ -21,24 +37,29 @@
     </style>
   </head>
   <body>
-    <div>
-      <h1>RSS Funnel Inspector</h1>
-      <p id="message"></p>
-      <form action="/login" method="post">
-        <input type="text" name="username" placeholder="Username" />
-        <input type="password" name="password" placeholder="Password" />
-        <input type="submit" value="Login" />
-      </form>
-      <script>
-        const message = document.getElementById("message");
-        const search = window.location.search;
-        if (search.includes("bad_auth")) {
-          message.textContent = "Invalid username or password";
-        } else if (search.includes("logged_out")) {
-          message.textContent = "You have been logged out";
-        } else if (search.includes("login_required")) {
-          message.textContent = "You must be logged in to access that page";
-        }
-      </script>
+    <h2>RSS Funnel Inspector</h2>
+    <p id="message" class="hidden"></p>
+    <form action="/login" method="post">
+      <input type="text" name="username" placeholder="Username" />
+      <input type="password" name="password" placeholder="Password" />
+      <input type="submit" value="Login" />
+    </form>
+    <footer><footer>
+      <p>Powered by <a href="https://github.com/shouya/rss-funnel">RSS Funnel</a></p>
+    </footer>
+    <script>
+      const message = document.getElementById("message");
+      const search = window.location.search;
+      if (search.includes("bad_auth")) {
+        message.classList.remove("hidden");
+        message.textContent = "Invalid username or password";
+      } else if (search.includes("logged_out")) {
+        message.classList.remove("hidden");
+        message.textContent = "You have been logged out";
+      } else if (search.includes("login_required")) {
+        message.classList.remove("hidden");
+        message.textContent = "You must be logged in to access that page";
+      }
+    </script>
   </body>
 </html>

--- a/inspector/src/login.html
+++ b/inspector/src/login.html
@@ -36,7 +36,7 @@
           message.textContent = "Invalid username or password";
         } else if (search.includes("logged_out")) {
           message.textContent = "You have been logged out";
-        } else if (search.includes("requires_login")) {
+        } else if (search.includes("login_required")) {
           message.textContent = "You must be logged in to access that page";
         }
       </script>

--- a/inspector/src/style.css
+++ b/inspector/src/style.css
@@ -93,9 +93,15 @@ h4 {
   }
 }
 
-#reload-config-button {
-  text-align: center;
-  margin-bottom: 0.5rem;
+#control-buttons {
+  display: flex;
+  flex-direction: row;
+  gap: 0.5rem;
+  & > .button {
+    flex: 1;
+    text-align: center;
+    margin-bottom: 0.5rem;
+  }
 }
 
 .button {
@@ -105,6 +111,10 @@ h4 {
   border-radius: 0.3rem;
   white-space: nowrap;
   transition: all 0.1s ease-in-out;
+  display: block;
+  /* make a.button look the same as div.button */
+  color: inherit;
+  text-decoration: none;
 
   &:hover {
     background-color: #f4f4f4;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -73,6 +73,7 @@ pub struct RootConfig {
 )]
 pub struct AuthConfig {
   pub username: String,
+  #[serde(skip_serializing)]
   pub password: String,
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -64,7 +64,16 @@ impl TestConfig {
   JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
 )]
 pub struct RootConfig {
+  pub auth: Option<AuthConfig>,
   pub endpoints: Vec<EndpointConfig>,
+}
+
+#[derive(
+  JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
+)]
+pub struct AuthConfig {
+  pub username: String,
+  pub password: String,
 }
 
 impl RootConfig {

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,4 +1,5 @@
 pub(crate) mod endpoint;
+mod auth;
 mod feed_service;
 #[cfg(feature = "inspector-ui")]
 mod inspector;

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,5 +1,5 @@
-pub(crate) mod endpoint;
 mod auth;
+mod endpoint;
 mod feed_service;
 #[cfg(feature = "inspector-ui")]
 mod inspector;

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -1,0 +1,71 @@
+use axum::{
+  extract::FromRequestParts,
+  response::{IntoResponse, Redirect, Response},
+  Extension, Form,
+};
+use axum_extra::extract::CookieJar;
+use http::request::Parts;
+
+use super::feed_service::FeedService;
+
+pub struct Auth;
+
+#[async_trait::async_trait]
+impl<S: Send + Sync> FromRequestParts<S> for Auth {
+  type Rejection = Response;
+
+  async fn from_request_parts(
+    parts: &mut Parts,
+    state: &S,
+  ) -> Result<Self, Self::Rejection> {
+    let feed_service: Extension<FeedService> =
+      Extension::from_request_parts(parts, state)
+        .await
+        .map_err(|e| e.into_response())?;
+
+    if !feed_service.requires_auth().await {
+      return Ok(Auth);
+    }
+
+    let cookie_jar = CookieJar::from_request_parts(parts, state)
+      .await
+      .map_err(|e| e.into_response())?;
+
+    let session_id = cookie_jar.get("session_id").ok_or_else(login)?.value();
+
+    if !feed_service.validate_session_id(session_id).await {
+      return Err(login());
+    }
+
+    Ok(Auth)
+  }
+}
+
+fn login() -> Response {
+  Redirect::to("/_inspector/login.html?requires_login=1").into_response()
+}
+
+#[derive(serde::Deserialize)]
+pub struct HandleLoginParams {
+  username: String,
+  password: String,
+}
+
+pub async fn handle_login(
+  cookie_jar: CookieJar,
+  Extension(feed_service): Extension<FeedService>,
+  Form(params): Form<HandleLoginParams>,
+) -> Response {
+  match feed_service.login(&params.username, &params.password).await {
+    Some(session_id) => {
+      let cookie_jar = cookie_jar.add(("session_id", session_id));
+      (cookie_jar, Redirect::to("/_inspector/index.html")).into_response()
+    }
+    _ => Redirect::to("/_inspector/login.html?bad_auth=1").into_response(),
+  }
+}
+
+pub async fn handle_logout(cookie_jar: CookieJar) -> Response {
+  let cookie_jar = cookie_jar.remove("session_id");
+  (cookie_jar, Redirect::to("/_inspector/login.html")).into_response()
+}

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -42,7 +42,7 @@ impl<S: Send + Sync> FromRequestParts<S> for Auth {
 }
 
 fn login() -> Response {
-  Redirect::to("/_inspector/login.html?requires_login=1").into_response()
+  Redirect::to("/_inspector/login.html?login_required=1").into_response()
 }
 
 #[derive(serde::Deserialize)]
@@ -67,5 +67,9 @@ pub async fn handle_login(
 
 pub async fn handle_logout(cookie_jar: CookieJar) -> Response {
   let cookie_jar = cookie_jar.remove("session_id");
-  (cookie_jar, Redirect::to("/_inspector/login.html")).into_response()
+  (
+    cookie_jar,
+    Redirect::to("/_inspector/login.html?logged_out=1"),
+  )
+    .into_response()
 }


### PR DESCRIPTION
Fixes #56.

This pull request implements authentication support with a very simple login page:

<img src="https://github.com/shouya/rss-funnel/assets/526598/43966b92-077a-4095-b2cc-cec60fb1d465" width="400"></img>

You can specify a username and password in the config to protect the inspector UI behind the login page:

``` yaml
auth:
  username: admin
  password: hunter2

endpoints:
  - ...
```

If the `auth` config is not specified, authentication will be disabled and the inspector UI is accessible publicly.

Note: the login feature is implemented in a very primitive way for the sake of the simplicity. Only one single user can be logged in at the same time. This means if if you try to log in from another browser, the existing session will be invalidated. Also, there is no session expiration mechanism. To log out, use the "Logout" button from the inspector UI, or simply clear your cookie.