### PR TITLE
fix(filters): support early return in `modify_post` and `modify_feed`

### DIFF
--- a/src/filter/js.rs
+++ b/src/filter/js.rs
@@ -96,7 +96,11 @@ impl FeedFilterConfig for ModifyPostConfig {
 
   async fn build(self) -> Result<Self::Filter, ConfigError> {
     let code = format!(
-      "async function modify_post(feed, post) {{ (function(){{ {} }})(); return post; }}",
+      "async function modify_post(feed, post) {{
+        const retval = await (async function(){{ {} }})();
+        if (retval === null) return null;
+        return post;
+      }}",
       self.code
     );
     JsConfig { code }.build().await
@@ -109,7 +113,10 @@ impl FeedFilterConfig for ModifyFeedConfig {
 
   async fn build(self) -> Result<Self::Filter, ConfigError> {
     let code = format!(
-      "function modify_feed(feed) {{ (function(){{ {} }})(); return feed; }}",
+      "async function modify_feed(feed) {{
+         await (async function(){{ {}; }})();
+         return feed;
+       }}",
       self.code
     );
     JsConfig { code }.build().await

--- a/src/filter/js.rs
+++ b/src/filter/js.rs
@@ -96,7 +96,7 @@ impl FeedFilterConfig for ModifyPostConfig {
 
   async fn build(self) -> Result<Self::Filter, ConfigError> {
     let code = format!(
-      "async function modify_post(feed, post) {{ {}; return post; }}",
+      "async function modify_post(feed, post) {{ (function(){{ {} }})(); return post; }}",
       self.code
     );
     JsConfig { code }.build().await
@@ -109,7 +109,7 @@ impl FeedFilterConfig for ModifyFeedConfig {
 
   async fn build(self) -> Result<Self::Filter, ConfigError> {
     let code = format!(
-      "function modify_feed(feed) {{ {}; return feed; }}",
+      "function modify_feed(feed) {{ (function(){{ {} }})(); return feed; }}",
       self.code
     );
     JsConfig { code }.build().await


### PR DESCRIPTION
Previously, the user code is embedded in a function that looks like this:

``` javascript
async function modify_post(feed, post) {
  <USER CODE>;
  return post;
}
```

It means in the filter config, if the user wants to early return, they must call `return post;` explicitly. This is a little clumsy given we want to give the illusion that the user no longer has to explicitly return post or anything.

I hope to enable the user to write code like this in `modify_post` and `modify_feed` filter:

``` javascript
if (condition 1) {
  // do no modify post by early return
  return;
}

if (condition 2) {
  // delete post by assigning it null;
  post = null;
  return;
}

if (condition 3) {
  // alternatively, delete post by returning null
  return null;
}

// normally edit the post
post.field = 'new value';
```

Because now the `return` statement for user code has different semantics from the `return` statement of `modify_post` function, we must wrap the user code in a different function.

This pull request changes the wrapper we embedded user code to:

``` javascript
async function modify_post(feed, post) {
  const retval = await (async function(){ <USER CODE> })();
  if (retval === null) {
    return null;
  }
  return post;
}
```