### PR TITLE
feat(inspector-ui): render note filter's value as documentation

### DIFF
--- a/inspector/src/Filter.js
+++ b/inspector/src/Filter.js
@@ -83,6 +83,10 @@ export class Filter {
     // return highlight_json(JSON.stringify(this.config, null, 2));
   }
 
+  render_note_config() {
+    return elt("p", { class: "note-filter" }, this.config);
+  }
+
   render_js_config() {
     return highlight_js(this.config);
   }

--- a/inspector/src/style.css
+++ b/inspector/src/style.css
@@ -224,6 +224,10 @@ ul#filter-list {
         white-space: pre-wrap;
         word-wrap: break-word;
       }
+      p.note-filter {
+        margin-top: 0;
+        margin-bottom: 0;
+      }
 
       ul {
         list-style: square;


### PR DESCRIPTION
The `note` filter's value is now rendered in variable pitch font inside a `<p>` tag instead of as json value.