### PR TITLE
feat(cli): specify server flags via environment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ tokio = { version = "1.36.0", features = ["macros", "net", "rt-multi-thread", "s
 lazy_static = "1.4.0"
 
 # Command line and config parsing
-clap = { version = "4.5.1", features = ["derive"] }
+clap = { version = "4.5.1", features = ["derive", "env"] }
 serde = { version = "1.0.197", features = ["derive", "rc"] }
 serde_yaml = "0.9.32"
 duration-str = { version = "0.7.1", default-features = false, features = ["serde"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,7 +15,7 @@ pub struct Cli {
   #[clap(subcommand)]
   subcmd: SubCommand,
 
-  #[clap(long, short)]
+  #[clap(long, short, env = "RSS_FUNNEL_CONFIG")]
   config: PathBuf,
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -24,7 +24,12 @@ use self::feed_service::FeedService;
 #[derive(Parser, Clone)]
 pub struct ServerConfig {
   /// The address to bind to
-  #[clap(long, short, default_value = "127.0.0.1:4080")]
+  #[clap(
+    long,
+    short,
+    default_value = "127.0.0.1:4080",
+    env = "RSS_FUNNEL_BIND"
+  )]
   bind: Arc<str>,
 
   /// Whether to enable the inspector UI
@@ -35,18 +40,20 @@ pub struct ServerConfig {
     num_args = 0..=1,
     require_equals = true,
     default_value = "true",
-    default_missing_value = "true"
+    default_missing_value = "true",
+    env = "RSS_FUNNEL_INSPECTOR_UI"
   )]
   inspector_ui: bool,
 
   /// Watch the config file for changes and restart the server
-  #[clap(long, short)]
+  #[clap(long, short, env = "RSS_FUNNEL_WATCH")]
   watch: bool,
 }
 
 impl ServerConfig {
   pub async fn run(self, config_path: &Path) -> Result<()> {
     if self.watch {
+      info!("watching config file for changes");
       self.run_with_fs_watcher(config_path).await
     } else {
       self.run_without_fs_watcher(config_path).await

--- a/src/server/feed_service.rs
+++ b/src/server/feed_service.rs
@@ -34,7 +34,7 @@ impl FeedService {
     for endpoint_config in root_config.endpoints.clone() {
       let path = endpoint_config.path_sans_slash().to_owned();
       let endpoint_service = endpoint_config.build().await?;
-      info!("loaded endpoint: {}", path);
+      info!("loaded endpoint: /{}", path);
       endpoints.insert(path, endpoint_service);
     }
 


### PR DESCRIPTION
It's often more convenient to specify the server flags via environment
than overriding the default command line. This pull request adds the
ability to specify the server flags via environment.

Currently, the following environments are supported:

| Variable                  | Default value    | Description                                                         |
|---------------------------|------------------|---------------------------------------------------------------------|
| `RSS_FUNNEL_BIND`         | `127.0.0.1:4080` | The server bind address                                             |
| `RSS_FUNNEL_INSPECTOR_UI` | `true`           | Whether or not to serve the inspector UI                            |
| `RSS_FUNNEL_WATCH`        | `false`          | Whether or not to watch config file change and automatically reload |
| `RSS_FUNNEL_CONFIG`       | unspecified      | The location of the config file.                                    |

Note: if you specify the options both from environment and command
line, the command line options will take precedence.