### PR TITLE
fix(filters): mark `client` and `filters` optional for merge filter

### DIFF
--- a/src/filter/merge.rs
+++ b/src/filter/merge.rs
@@ -43,17 +43,17 @@ pub struct MergeFullConfig {
   parallelism: Option<usize>,
   /// Client configuration
   #[serde(default)]
-  client: ClientConfig,
+  client: Option<ClientConfig>,
   /// Filters to apply to the merged feed
   #[serde(default)]
-  filters: FilterPipelineConfig,
+  filters: Option<FilterPipelineConfig>,
 }
 
 impl From<MergeSimpleConfig> for MergeFullConfig {
   fn from(config: MergeSimpleConfig) -> Self {
     Self {
       source: config.source,
-      client: ClientConfig::default(),
+      client: Default::default(),
       filters: Default::default(),
       parallelism: None,
     }
@@ -80,8 +80,10 @@ impl FeedFilterConfig for MergeConfig {
       source,
       parallelism,
     } = self.into();
-    let client = client.build(Duration::from_secs(15 * 60))?;
-    let filters = filters.build().await?;
+    let client = client
+      .unwrap_or_default()
+      .build(Duration::from_secs(15 * 60))?;
+    let filters = filters.unwrap_or_default().build().await?;
     let sources = source
       .into_vec()
       .into_iter()


### PR DESCRIPTION
Previously, the `client` and `filters` fields were required (but has a default value). One So if the user don't specify the `client` and `filters` fields, they'll default to a struct with the default values.

One side effect is that the inspector-ui will try render the all-empty field for `client` even if the user didn't specify it `client` their config.

With this change, I wrapped the `client` and `filters` fields with `Option` box, so now the `client` field will appear as `null` when rendered in json.