### PR TITLE
feat: `case_sensitive` option for `highlight` and `sanitize` filter

### DIFF
--- a/src/filter/highlight.rs
+++ b/src/filter/highlight.rs
@@ -111,13 +111,13 @@ impl Highlight {
     case_sensitive: bool,
   ) -> Result<Self, ConfigError> {
     let regexset = RegexSetBuilder::new(patterns)
-      .case_insensitive(case_sensitive)
+      .case_insensitive(!case_sensitive)
       .build()?;
     let patterns = patterns
       .iter()
       .map(|p| {
         RegexBuilder::new(p.as_ref())
-          .case_insensitive(case_sensitive)
+          .case_insensitive(!case_sensitive)
           .build()
       })
       .collect::<Result<Vec<Regex>, _>>()?;
@@ -250,7 +250,7 @@ mod test {
   #[test]
   fn test_highlighting() {
     let keywords = vec!["foo", "bar"];
-    let highlight = Highlight::new(&keywords, "#ffff00".into())
+    let highlight = Highlight::new(&keywords, "#ffff00".into(), false)
       .expect("failed to build highlighter");
 
     let html = r#"<html><p class="foo">FOO<div><!-- bar -->foo<br> bar</div></p></html>
@@ -283,6 +283,7 @@ highlight:
           keywords: vec!["foo".into(), "bar".into()],
         },
         bg_color: Some("#ffff00".into()),
+        case_sensitive: None,
       },
     );
 
@@ -298,6 +299,7 @@ highlight:
           patterns: vec![r"\bfoo\b".into()],
         },
         bg_color: Some("#ffff00".into()),
+        case_sensitive: None,
       },
     );
   }


### PR DESCRIPTION
This PR adds a `case_sensitive` option to the `highlight` and `sanitize` filters. By default, it is set to `false`.

When `case_sensitive` is `true` for the `highlight` filter, it will only highlight matches that have the same case as the search term.

Similarly, `case_sensitive` controls whether the `from` field of the `replace` operation in the `sanitize` filter matches the case. Note that currently, it's not possible to specify a case-sensitive `remove` operation. As a workaround, you 
can use a case-sensitive `replace` operation with `to: ""`.

Example:

```yaml
highlight:
  keywords:
    - foo
    - bar
  bg_color: '#ffff00'
  case_sensitive: true

sanitize:
  - remove: "foo"
  - remove_regex: '\\d+'
  - replace:
      from: "bar"
      to: "baz"
      case_sensitive: true
  - replace_regex:
      from: '\\w+'
      to: "qux"
      case_sensitive: true