### PR TITLE
feat: reliably detect config file modification

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -70,8 +70,10 @@ impl ServerConfig {
 
     // watcher must not be dropped until the end of the function
     let mut watcher = Watcher::new(config_path)?;
-    watcher.setup()?;
-    let mut change_alert = watcher.take_change_alert().expect(" failed");
+    let mut change_alert =
+      watcher.take_change_alert().expect("change alert taken");
+
+    tokio::task::spawn(watcher.run());
 
     // signal for reload on config update
     let feed_service_clone = feed_service.clone();

--- a/src/server/watcher.rs
+++ b/src/server/watcher.rs
@@ -1,0 +1,87 @@
+use std::path::{Path, PathBuf};
+
+use tokio::sync::mpsc::{self, Receiver, Sender};
+use tracing::error;
+
+use crate::util::{ConfigError, Result};
+
+pub struct Watcher {
+  path: PathBuf,
+  watcher: Option<notify::RecommendedWatcher>,
+  rx: Option<Receiver<()>>,
+  tx: Sender<()>,
+}
+
+impl Watcher {
+  pub fn new(path: &Path) -> Result<Self> {
+    let (tx, rx) = mpsc::channel(1);
+
+    // sometimes the editor may touch the file multiple times in quick
+    // succession when saving, so we debounce the events
+    let rx = debounce(std::time::Duration::from_millis(500), rx);
+
+    Ok(Self {
+      path: path.to_owned(),
+      watcher: None,
+      rx: Some(rx),
+      tx,
+    })
+  }
+
+  pub fn take_change_alert(&mut self) -> Option<Receiver<()>> {
+    self.rx.take()
+  }
+
+  pub fn setup(&mut self) -> Result<()> {
+    use notify::{Event, RecursiveMode, Watcher};
+
+    let tx = self.tx.clone();
+    let event_handler = move |event: Result<Event, notify::Error>| match event {
+      Ok(event) if event.kind.is_modify() => {
+        tx.blocking_send(()).unwrap();
+      }
+      Ok(e) => {
+        dbg!(e);
+      }
+      Err(_) => {
+        error!("file watcher error: {:?}", event);
+      }
+    };
+
+    let mut watcher =
+      notify::recommended_watcher(event_handler).map_err(|e| {
+        ConfigError::Message(format!("failed to create file watcher: {:?}", e))
+      })?;
+
+    watcher
+      .watch(&self.path, RecursiveMode::NonRecursive)
+      .map_err(|e| {
+        ConfigError::Message(format!("failed to watch file: {:?}", e))
+      })?;
+
+    Ok(())
+  }
+}
+
+fn debounce<T: Send + 'static>(
+  duration: std::time::Duration,
+  mut rx: Receiver<T>,
+) -> Receiver<T> {
+  let (debounced_tx, debounced_rx) = mpsc::channel(1);
+  tokio::task::spawn(async move {
+    let mut last = None;
+    loop {
+      tokio::select! {
+        val = rx.recv() => {
+          last = val;
+        }
+        _ = tokio::time::sleep(duration) => {
+          if let Some(val) = last.take() {
+            debounced_tx.send(val).await.unwrap();
+          }
+        }
+      }
+    }
+  });
+  debounced_rx
+}


### PR DESCRIPTION
As reported in #80, the fs watcher previously cannot detect config changes made using vim.

Vim's default save file behavior (controlled by `backupcopy` option) is to save the file under a new name and then rename it to override the original file. As such, the inode of the previously watched file is gone and will no longer trigger inotify events.

This PR addresses the issue by additionally detecting the file deletion event, and re-launch the watcher on the same path when the file is found deleted.