### PR TITLE
feat: select publication date in `split` filter

### DIFF
--- a/src/filter/html.rs
+++ b/src/filter/html.rs
@@ -403,12 +403,12 @@ impl Split {
       || titles.len() != pub_dates.len()
     {
       let msg = format!(
-        "Selector error: title ({}), link ({}), \
-         description ({}), and author ({}) count mismatch",
+        "Selector error: title ({}), link ({}), description ({}), author ({}), and date ({}) count mismatch",
         titles.len(),
         links.len(),
         descriptions.len(),
-        authors.len()
+        authors.len(),
+        pub_dates.len()
       );
       return Err(Error::Message(msg));
     }


### PR DESCRIPTION
Previously, the `split` filter is only able to generate a feed whose items has title, link, author, and description.

However, the users can also benefit from having a field for publication date. The publication date field will allow the feed readers to sort by date, and also allow the items to be sorted correctly in the `merge` filter.

This PR adds a new config field to the `split` filter named `date_selector` to enable users to select the publication date. The selector is optional, and has the same syntax as other selector fields.

One thing to note is that the code employs some heuristic to guess the publication date from the selected elements. The heuristic is as follows:

1. check the `textContent` for valid date string
2. check through all the attributes for valid date string

The following formats are recognized valid date string:

- rfc3339 (also known as iso8601): `1996-12-19T16:39:57-08:00`
- rfc2822: `Thu, 19 Dec 1996 16:39:57 -0800`

Here's an example using `date_selector` for extracting RSS feed for GitHub releases:

```yaml
  - path: /github-release.xml
    note: Generate release feed for any GitHub repo
    filters:
      - note: Try input <code>https://github.com/shouya/rss-funnel/releases</code> in the source textbox!
      - split:
          title_selector: ".Box .f1 .Link"
          link_selector: ".Box .f1 .Link"
          description_selector: ".Box .markdown-body"
          date_selector: "section .mr-3 relative-time"
      - modify_post: |
          const project_name = feed.title.split(" · ")[1];
          post.title = `New release for ${project_name}: ${post.title}`;
```