### PR TITLE
fix: merge feeds with extra namespaces

### DIFF
--- a/src/feed.rs
+++ b/src/feed.rs
@@ -176,9 +176,11 @@ impl Feed {
   pub fn merge(&mut self, other: Feed) -> Result<()> {
     match (self, other) {
       (Feed::Rss(channel), Feed::Rss(other)) => {
+        channel.namespaces.extend(other.namespaces);
         channel.items.extend(other.items);
       }
       (Feed::Atom(feed), Feed::Atom(other)) => {
+        feed.namespaces.extend(other.namespaces);
         feed.entries.extend(other.entries);
       }
       (Feed::Rss(_), _) => {


### PR DESCRIPTION
Previously, the `merge` filter only merges the items from the other feeds. It fails in case where the merged feeds have different set of namespaces. If the source feed doesn't have the necessary namespaces used by the items from merged feeds, then the output xml will invalid. The issue was first reported in https://github.com/shouya/rss-funnel/issues/86.

This PR fixes the issue by merging the namespaces of the merged feeds into the source feed.