### PR TITLE
feat(filters): limit the number of posts

### DIFF
--- a/src/client/cache.rs
+++ b/src/client/cache.rs
@@ -32,9 +32,7 @@ impl ResponseCache {
 
   pub fn get_cached(&self, url: &Url) -> Option<Response> {
     let mut map = self.map.write().ok()?;
-    let Some(entry) = map.get(url) else {
-      return None;
-    };
+    let entry = map.get(url)?;
     if entry.created.elapsed() > self.timeout {
       map.pop(url);
       return None;

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -564,9 +564,7 @@ fn fix_escaping_in_extension_attr(feed: &mut atom_syndication::Feed) {
 fn rss_item_timestamp(item: &rss::Item) -> Option<i64> {
   use chrono::FixedOffset;
 
-  let Some(pub_date) = item.pub_date.as_ref() else {
-    return None;
-  };
+  let pub_date = item.pub_date.as_ref()?;
 
   let Ok(date) = DateTime::<FixedOffset>::parse_from_rfc2822(pub_date) else {
     return None;

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -189,4 +189,5 @@ define_filters!(
   Merge => merge::MergeConfig, "Merge extra feed into the main feed";
   Note => note::NoteFilterConfig, "Add non-functional comment";
   ConvertTo => convert::ConvertToConfig, "Convert feed to another format";
+  Limit => limit::LimitConfig, "Limit the number of posts";
 );

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -3,6 +3,7 @@ mod full_text;
 mod highlight;
 mod html;
 mod js;
+mod limit;
 mod merge;
 mod note;
 mod sanitize;

--- a/src/filter/limit.rs
+++ b/src/filter/limit.rs
@@ -15,7 +15,7 @@ use super::{FeedFilter, FeedFilterConfig, FilterContext};
   JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
 )]
 #[serde(untagged)]
-enum LimitConfig {
+pub enum LimitConfig {
   Count(LimitByCount),
   Duration(LimitByDuration),
 }
@@ -25,14 +25,14 @@ enum LimitConfig {
 )]
 #[serde(transparent)]
 /// Only this many posts are kept.
-struct LimitByCount(usize);
+pub struct LimitByCount(usize);
 
 #[derive(
   JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
 )]
 #[serde(transparent)]
-/// Only posts published within this duration are kept.
-struct LimitByDuration(
+/// Only posts published within this duration are kept. (Examples: "1d", "3w")
+pub struct LimitByDuration(
   #[serde(deserialize_with = "duration_str::deserialize_duration")]
   #[schemars(with = "String")]
   Duration,

--- a/src/filter/limit.rs
+++ b/src/filter/limit.rs
@@ -1,0 +1,77 @@
+use std::time::Duration;
+
+use chrono::Utc;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+  feed::Feed,
+  util::{ConfigError, Error},
+};
+
+use super::{FeedFilter, FeedFilterConfig, FilterContext};
+
+#[derive(
+  JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
+)]
+#[serde(untagged)]
+enum LimitConfig {
+  Count(LimitByCount),
+  Duration(LimitByDuration),
+}
+
+#[derive(
+  JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
+)]
+#[serde(transparent)]
+/// Only this many posts are kept.
+struct LimitByCount(usize);
+
+#[derive(
+  JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
+)]
+#[serde(transparent)]
+/// Only posts published within this duration are kept.
+struct LimitByDuration(
+  #[serde(deserialize_with = "duration_str::deserialize_duration")]
+  #[schemars(with = "String")]
+  Duration,
+);
+
+pub struct Limit {
+  config: LimitConfig,
+}
+
+#[async_trait::async_trait]
+impl FeedFilterConfig for LimitConfig {
+  type Filter = Limit;
+
+  async fn build(self) -> Result<Self::Filter, ConfigError> {
+    Ok(Limit { config: self })
+  }
+}
+
+#[async_trait::async_trait]
+impl FeedFilter for Limit {
+  async fn run(
+    &self,
+    _ctx: &mut FilterContext,
+    mut feed: Feed,
+  ) -> Result<Feed, Error> {
+    match &self.config {
+      LimitConfig::Count(LimitByCount(count)) => {
+        let mut posts = feed.take_posts();
+        posts.truncate(*count);
+        feed.set_posts(posts);
+        Ok(feed)
+      }
+      LimitConfig::Duration(LimitByDuration(duration)) => {
+        let cutoff = Utc::now() - *duration;
+        let mut posts = feed.take_posts();
+        posts.retain(|post| post.pub_date().is_some_and(|t| t >= cutoff));
+        feed.set_posts(posts);
+        Ok(feed)
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a new filter `limit` that allows limiting the number of posts. This filter operates in two modes:

- count mode: only the first `n` posts are kept
- duration mode: only posts that are created within `duration` are kept

The format of duration string follows the same format as any other duration strings. Find more information about the duration format at [duration_str](https://docs.rs/duration-str).

The config syntax as follows:

``` yaml
  - path: /hackernews-fresh.xml
    source: https://news.ycombinator.com/rss
    filters:
      - limit: 8h

  - path: /hackernews-first-10.xml
    source: https://news.ycombinator.com/rss
    filters:
      - limit: 10
```

Fixes https://github.com/shouya/rss-funnel/issues/88.