### PR TITLE
fix: handle different body fields

### DIFF
--- a/src/feed.rs
+++ b/src/feed.rs
@@ -1,4 +1,5 @@
 mod conversion;
+mod extension;
 
 use chrono::DateTime;
 use paste::paste;
@@ -12,6 +13,8 @@ use crate::html::html_body;
 use crate::source::FromScratch;
 use crate::util::Error;
 use crate::util::Result;
+
+use extension::ExtensionExt;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(untagged)]
@@ -325,6 +328,12 @@ impl Post {
       Post::Rss(item) => {
         item.content.as_mut().map(|v| bodies.push(v));
         item.description.as_mut().map(|v| bodies.push(v));
+        item
+          .extensions
+          .tags_mut_with_names(&["media:description"])
+          .into_iter()
+          .filter_map(|tag| tag.value.as_mut())
+          .for_each(|v| bodies.push(v));
       }
       Post::Atom(item) => {
         item
@@ -333,11 +342,18 @@ impl Post {
           .and_then(|c| c.value.as_mut())
           .map(|v| bodies.push(v));
         item.summary.as_mut().map(|s| bodies.push(&mut s.value));
+        item
+          .extensions
+          .tags_mut_with_names(&["media:description"])
+          .into_iter()
+          .filter_map(|tag| tag.value.as_mut())
+          .for_each(|v| bodies.push(v));
       }
     }
     bodies
   }
 
+  // Please make sure this function matches the order of bodies_mut
   #[allow(clippy::option_map_unit_fn)]
   pub fn bodies(&self) -> Vec<&str> {
     let mut bodies = Vec::new();
@@ -345,6 +361,12 @@ impl Post {
       Post::Rss(item) => {
         item.content.as_deref().map(|v| bodies.push(v));
         item.description.as_deref().map(|v| bodies.push(v));
+        item
+          .extensions
+          .tags_with_names(&["media:description"])
+          .into_iter()
+          .filter_map(|tag| tag.value.as_deref())
+          .for_each(|v| bodies.push(v));
       }
       Post::Atom(item) => {
         item
@@ -353,6 +375,12 @@ impl Post {
           .and_then(|c| c.value.as_deref())
           .map(|v| bodies.push(v));
         item.summary.as_ref().map(|s| bodies.push(&s.value));
+        item
+          .extensions
+          .tags_with_names(&["media:description"])
+          .into_iter()
+          .filter_map(|tag| tag.value.as_deref())
+          .for_each(|v| bodies.push(v));
       }
     }
     bodies

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -386,7 +386,7 @@ impl Post {
     bodies
   }
 
-  pub fn modify_body(&mut self, mut f: impl FnMut(&mut String)) {
+  pub fn modify_bodies(&mut self, mut f: impl FnMut(&mut String)) {
     for body in self.bodies_mut() {
       f(body);
     }

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -352,6 +352,33 @@ impl Post {
 
     self.ensure_body()
   }
+
+  // read only version of modify_body. you should ensure the visiting
+  // order
+  pub fn visit_body(&self, f: impl FnMut(&str)) {
+    match self {
+      Post::Rss(item) => {
+        item.content.as_deref().map(f);
+        item.description.as_deref().map(f);
+      }
+      Post::Atom(item) => {
+        item
+          .content
+          .as_ref()
+          .and_then(|c| c.value.as_deref())
+          .map(f);
+        item.summary.as_ref().map(|s| f(&s.value));
+      }
+    }
+  }
+
+  // a post can have many fields that shows as the body in the feed. this function
+  // returns all of them.
+  pub fn body_values(&self) -> Vec<&str> {
+    let mut values = Vec::new();
+    self.visit_body(|v| values.push(v));
+    values
+  }
 }
 
 impl Post {

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -334,6 +334,11 @@ impl Post {
           .into_iter()
           .filter_map(|tag| tag.value.as_mut())
           .for_each(|v| bodies.push(v));
+        item
+          .itunes_ext
+          .as_mut()
+          .and_then(|ext| ext.summary.as_mut())
+          .map(|v| bodies.push(v));
       }
       Post::Atom(item) => {
         item
@@ -367,6 +372,11 @@ impl Post {
           .into_iter()
           .filter_map(|tag| tag.value.as_deref())
           .for_each(|v| bodies.push(v));
+        item
+          .itunes_ext
+          .as_ref()
+          .and_then(|ext| ext.summary.as_deref())
+          .map(|v| bodies.push(v));
       }
       Post::Atom(item) => {
         item

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -315,15 +315,18 @@ impl Post {
     }
   }
 
+  // the visiting order should match the actual display order in rss
+  // readers. This allows ensure_body to return the body field that is
+  // most likely to affect the actual appearance.
   pub fn modify_body(&mut self, f: impl FnMut(&mut String)) {
     match self {
       Post::Rss(item) => {
-        item.description.as_mut().map(f);
         item.content.as_mut().map(f);
+        item.description.as_mut().map(f);
       }
       Post::Atom(item) => {
-        item.summary.as_mut().map(|s| f(&mut s.value));
         item.content.as_mut().and_then(|c| c.value.as_mut()).map(f);
+        item.summary.as_mut().map(|s| f(&mut s.value));
       }
     }
   }

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -314,6 +314,7 @@ impl Post {
       Post::Atom(item) => Some(item.updated),
     }
   }
+
   pub fn modify_body(&mut self, f: impl FnMut(&mut String)) {
     match self {
       Post::Rss(item) => {
@@ -327,6 +328,27 @@ impl Post {
     }
   }
 
+  pub fn ensure_body(&mut self) -> &mut String {
+    let mut body = None;
+    self.modify_body(|b| {
+      body.get_or_insert(b);
+    });
+
+    if let Some(body) = body {
+      return body;
+    }
+
+    match self {
+      Post::Rss(item) => {
+        item.description = Some(String::new());
+      }
+      Post::Atom(item) => {
+        item.summary = Some(atom_syndication::Text::html(String::new()));
+      }
+    }
+
+    self.ensure_body()
+  }
 }
 
 impl Post {

--- a/src/feed/extension.rs
+++ b/src/feed/extension.rs
@@ -1,0 +1,100 @@
+use std::collections::BTreeMap;
+
+pub struct TagRef<'a> {
+  pub name: &'a String,
+  pub attrs: &'a BTreeMap<String, String>,
+  pub value: &'a Option<String>,
+}
+
+pub struct TagRefMut<'a> {
+  pub name: &'a mut String,
+  pub attrs: &'a mut BTreeMap<String, String>,
+  pub value: &'a mut Option<String>,
+}
+
+pub trait ExtensionExt {
+  fn tags(&self) -> Vec<TagRef>;
+  fn tags_mut(&mut self) -> Vec<TagRefMut>;
+
+  fn tags_mut_with_names(&mut self, names: &[&str]) -> Vec<TagRefMut> {
+    self
+      .tags_mut()
+      .into_iter()
+      .filter(|tag| names.contains(&tag.name.as_str()))
+      .collect()
+  }
+
+  fn tags_with_names(&self, names: &[&str]) -> Vec<TagRef> {
+    self
+      .tags()
+      .into_iter()
+      .filter(|tag| names.contains(&tag.name.as_str()))
+      .collect()
+  }
+}
+
+macro_rules! impl_extension_ext {
+  ($ty:ty) => {
+    impl ExtensionExt for $ty {
+      fn tags(&self) -> Vec<TagRef> {
+        let tag = TagRef {
+          name: &self.name,
+          attrs: &self.attrs,
+          value: &self.value,
+        };
+
+        let mut tags = vec![tag];
+        for children in self.children.values() {
+          tags.extend(children.iter().flat_map(|ext| ext.tags()));
+        }
+        tags
+      }
+
+      fn tags_mut(&mut self) -> Vec<TagRefMut> {
+        let tag = TagRefMut {
+          name: &mut self.name,
+          attrs: &mut self.attrs,
+          value: &mut self.value,
+        };
+
+        let mut tags = vec![tag];
+        for children in self.children.values_mut() {
+          tags.extend(children.iter_mut().flat_map(|ext| ext.tags_mut()));
+        }
+        tags
+      }
+    }
+  };
+}
+
+// These two structs has exactly the same structure but are different
+// types since they belong to different crates.
+impl_extension_ext!(atom_syndication::extension::Extension);
+impl_extension_ext!(rss::extension::Extension);
+
+impl<T> ExtensionExt for BTreeMap<String, BTreeMap<String, Vec<T>>>
+where
+  T: ExtensionExt,
+{
+  fn tags(&self) -> Vec<TagRef> {
+    self
+      .values()
+      .flat_map(|children| {
+        children
+          .values()
+          .flat_map(|exts| exts.iter().flat_map(|ext| ext.tags()))
+      })
+      .collect()
+  }
+
+  fn tags_mut(&mut self) -> Vec<TagRefMut> {
+    self
+      .values_mut()
+      .flat_map(|children| {
+        children
+          .values_mut()
+          .flat_map(|exts| exts.iter_mut().flat_map(|ext| ext.tags_mut()))
+      })
+      .collect()
+  }
+}

--- a/src/filter/full_text.rs
+++ b/src/filter/full_text.rs
@@ -25,7 +25,7 @@ pub struct FullTextConfig {
   parallelism: Option<usize>,
   /// Whether to simplify the HTML before saving it
   simplify: Option<bool>,
-  /// Whether to append the full text to the description or replace it
+  /// Whether to append the full text to the body or replace it
   append_mode: Option<bool>,
   /// Keep only content inside an element of the full text
   keep_element: Option<KeepElementConfig>,
@@ -126,7 +126,7 @@ impl FullTextFilter {
 
   async fn fetch_full_post(&self, mut post: Post) -> Result<Post> {
     // if anything went wrong when fetching the full text, we simply
-    // append the error message to the description instead of failing
+    // append the error message to the body instead of failing
     // completely.
     match self.try_fetch_full_post(&mut post).await {
       Ok(_) => Ok(post),

--- a/src/filter/full_text.rs
+++ b/src/filter/full_text.rs
@@ -105,7 +105,7 @@ impl FullTextFilter {
     .await?;
 
     post.ensure_body();
-    post.modify_body(|body| {
+    post.modify_bodies(|body| {
       if self.append_mode {
         body.push_str("\n<br><hr><br>\n");
         body.push_str(&text);
@@ -132,7 +132,7 @@ impl FullTextFilter {
       Ok(_) => Ok(post),
       Err(e) => {
         let message = format!("\n<br>\n<br>\nerror fetching full text: {}", e);
-        post.modify_body(|body| {
+        post.modify_bodies(|body| {
           body.push_str(&message);
         });
         Ok(post)

--- a/src/filter/full_text.rs
+++ b/src/filter/full_text.rs
@@ -93,24 +93,26 @@ impl FullTextFilter {
 
   async fn try_fetch_full_post(&self, post: &mut Post) -> Result<()> {
     let link = post.link_or_err()?.to_owned();
-    let mut text = self.fetch_html(&link).await?;
+    let text = self.fetch_html(&link).await?;
 
     // Optimization: the strip_post_content can be CPU intensive. Spawn the blocking
     // task on a different CPU to improve parallelism.
     let simplify = self.simplify;
     let keep_element = Arc::new(self.keep_element.clone());
-    text = tokio::task::spawn_blocking(move || {
+    let text = tokio::task::spawn_blocking(move || {
       strip_post_content(text, &link, simplify, keep_element)
     })
     .await?;
 
-    let description = post.description_or_insert();
-    if self.append_mode {
-      description.push_str("\n<br><hr><br>\n");
-      description.push_str(&text);
-    } else {
-      *description = text;
-    };
+    post.ensure_body();
+    post.modify_body(|body| {
+      if self.append_mode {
+        body.push_str("\n<br><hr><br>\n");
+        body.push_str(&text);
+      } else {
+        body.replace_range(.., &text);
+      };
+    });
 
     if !self.keep_guid {
       if let Some(mut guid) = post.guid().map(|v| v.to_string()) {
@@ -130,7 +132,9 @@ impl FullTextFilter {
       Ok(_) => Ok(post),
       Err(e) => {
         let message = format!("\n<br>\n<br>\nerror fetching full text: {}", e);
-        post.description_or_insert().push_str(&message);
+        post.modify_body(|body| {
+          body.push_str(&message);
+        });
         Ok(post)
       }
     }
@@ -178,17 +182,7 @@ fn strip_post_content(
   }
 
   if let Some(k) = keep_element.as_ref() {
-    match k.filter_description(&text) {
-      Some(filtered) => {
-        text = filtered;
-      }
-      None => {
-        text = format!(
-          "<p>Failed to filter description with keep_element</p>\n{}",
-          text
-        );
-      }
-    }
+    k.filter_body(&mut text)
   }
 
   text

--- a/src/filter/highlight.rs
+++ b/src/filter/highlight.rs
@@ -14,7 +14,7 @@ use crate::{
 #[derive(
   JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
 )]
-/// Highlight the given keywords in the feed's description
+/// Highlight the given keywords in the post's body
 pub struct HighlightConfig {
   #[serde(flatten)]
   keywords: KeywordsOrPatterns,
@@ -129,8 +129,8 @@ impl Highlight {
     })
   }
 
-  fn highlight_html(&self, description: &str) -> String {
-    let mut html = Html::parse_fragment(description);
+  fn highlight_html(&self, body: &str) -> String {
+    let mut html = Html::parse_fragment(body);
     let text_node_ids: Vec<NodeId> = html
       .tree
       .nodes()

--- a/src/filter/highlight.rs
+++ b/src/filter/highlight.rs
@@ -221,9 +221,9 @@ impl FeedFilter for Highlight {
     let mut posts = feed.take_posts();
 
     for post in &mut posts {
-      if let Some(description) = post.description_mut() {
-        *description = self.highlight_html(description);
-      }
+      post.modify_body(|body| {
+        *body = self.highlight_html(body);
+      });
     }
 
     feed.set_posts(posts);

--- a/src/filter/highlight.rs
+++ b/src/filter/highlight.rs
@@ -221,7 +221,7 @@ impl FeedFilter for Highlight {
     let mut posts = feed.take_posts();
 
     for post in &mut posts {
-      post.modify_body(|body| {
+      post.modify_bodies(|body| {
         *body = self.highlight_html(body);
       });
     }

--- a/src/filter/html.rs
+++ b/src/filter/html.rs
@@ -209,7 +209,7 @@ pub struct SplitConfig {
   /// The CSS selector for the body elements. The innerHTML of
   /// the selected elements will be used. If specified, it must select
   /// the same number of elements as title_selector.
-  #[deprecated]
+  #[deprecated(note = "Use `body_selector` instead")]
   description_selector: Option<String>,
   /// The CSS selector for the body elements. The innerHTML of
   /// the selected elements will be used. If specified, it must select

--- a/src/filter/html.rs
+++ b/src/filter/html.rs
@@ -93,7 +93,7 @@ impl FeedFilter for RemoveElement {
     let mut posts = feed.take_posts();
 
     for post in &mut posts {
-      post.modify_body(|body| {
+      post.modify_bodies(|body| {
         self.filter_body(body);
       })
     }
@@ -186,7 +186,7 @@ impl FeedFilter for KeepElement {
     let mut posts = feed.take_posts();
 
     for post in &mut posts {
-      post.modify_body(|body| self.filter_body(body));
+      post.modify_bodies(|body| self.filter_body(body));
     }
 
     feed.set_posts(posts);
@@ -349,7 +349,7 @@ impl Split {
 
   fn prepare_template(&self, post: &Post) -> Post {
     let mut template_post = post.clone();
-    template_post.modify_body(|body| body.clear());
+    template_post.modify_bodies(|body| body.clear());
 
     if self.author_selector.is_some() {
       if let Some(author) = template_post.author_mut() {
@@ -371,7 +371,7 @@ impl Split {
     template.set_title(title);
     template.set_link(link);
     if let Some(new_body) = body {
-      template.modify_body(|body| body.replace_range(.., new_body));
+      template.modify_bodies(|body| body.replace_range(.., new_body));
     }
     if let Some(author) = author {
       template.set_author(author);

--- a/src/filter/html.rs
+++ b/src/filter/html.rs
@@ -343,9 +343,7 @@ impl Split {
 
   fn prepare_template(&self, post: &Post) -> Post {
     let mut template_post = post.clone();
-    if let Some(description) = template_post.description_mut() {
-      description.clear()
-    }
+    template_post.modify_body(|body| body.clear());
 
     if self.author_selector.is_some() {
       if let Some(author) = template_post.author_mut() {
@@ -367,7 +365,7 @@ impl Split {
     template.set_title(title);
     template.set_link(link);
     if let Some(description) = description {
-      template.set_description(description);
+      template.modify_body(|body| body.replace_range(.., description));
     }
     if let Some(author) = author {
       template.set_author(author);
@@ -381,7 +379,8 @@ impl Split {
   fn split(&self, post: &Post) -> Result<Vec<Post>> {
     let mut posts = vec![];
 
-    let doc = Html::parse_fragment(post.description_or_err()?);
+    let body = post.ensure_body();
+    let doc = Html::parse_fragment(body);
 
     let titles = self.select_title(&doc)?;
     let links = self.select_link(post.link_or_err()?, &doc)?;

--- a/src/filter/sanitize.rs
+++ b/src/filter/sanitize.rs
@@ -129,7 +129,7 @@ impl Sanitize {
         SanitizeOp::Replace(needle, repl) => (needle, repl.as_str()),
       };
 
-      if let Cow::Owned(o) = needle.replace_all(&body, repl) {
+      if let Cow::Owned(o) = needle.replace_all(body, repl) {
         *body = o;
       }
     }

--- a/src/filter/sanitize.rs
+++ b/src/filter/sanitize.rs
@@ -145,7 +145,7 @@ impl FeedFilter for Sanitize {
   ) -> Result<Feed> {
     let mut posts = feed.take_posts();
     for post in &mut posts {
-      post.modify_body(|body| self.filter_body(body));
+      post.modify_bodies(|body| self.filter_body(body));
     }
 
     feed.set_posts(posts);

--- a/src/filter/select.rs
+++ b/src/filter/select.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use regex::{RegexSet, RegexSetBuilder};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -127,6 +129,8 @@ impl MatchConfig {
 #[serde(rename_all = "snake_case")]
 enum Field {
   Title,
+  Body,
+  #[deprecated(note = "use `body` instead")]
   Content,
   Any,
 }
@@ -135,7 +139,8 @@ impl Field {
   fn extract<'a>(&self, post: &'a crate::feed::Post) -> Vec<&'a str> {
     match self {
       Self::Title => post.title().into_iter().collect(),
-      Self::Content => post.bodies(),
+      #[allow(deprecated)]
+      Self::Body | Self::Content => post.bodies(),
       Self::Any => post.title().into_iter().chain(post.bodies()).collect(),
     }
   }

--- a/src/filter/select.rs
+++ b/src/filter/select.rs
@@ -135,12 +135,8 @@ impl Field {
   fn extract<'a>(&self, post: &'a crate::feed::Post) -> Vec<&'a str> {
     match self {
       Self::Title => post.title().into_iter().collect(),
-      Self::Content => post.body_values(),
-      Self::Any => post
-        .title()
-        .into_iter()
-        .chain(post.body_values().into_iter())
-        .collect(),
+      Self::Content => post.bodies(),
+      Self::Any => post.title().into_iter().chain(post.bodies()).collect(),
     }
   }
 }

--- a/src/filter/select.rs
+++ b/src/filter/select.rs
@@ -133,15 +133,15 @@ enum Field {
 
 impl Field {
   fn extract<'a>(&self, post: &'a crate::feed::Post) -> Vec<&'a str> {
-    let vec = match self {
-      Self::Title => vec![post.title()],
-      Self::Content => vec![post.description()],
-      Self::Any => {
-        vec![post.title(), post.description()]
-      }
-    };
-
-    vec.into_iter().flatten().collect()
+    match self {
+      Self::Title => post.title().into_iter().collect(),
+      Self::Content => post.body_values(),
+      Self::Any => post
+        .title()
+        .into_iter()
+        .chain(post.body_values().into_iter())
+        .collect(),
+    }
   }
 }
 

--- a/src/filter/select.rs
+++ b/src/filter/select.rs
@@ -301,12 +301,12 @@ mod test {
       path: /feed.xml
       source: fixture:///youtube.xml
       filters:
-        - keep_only: ElEcT
+        - keep_only: ElecTric
     "#;
 
     let mut feed = fetch_endpoint(config, "").await;
     let posts = feed.take_posts();
-    assert_eq!(posts.len(), 1);
+    assert_eq!(posts.len(), 2);
     assert_eq!(posts[0].title().unwrap(), "This Crystal Is ELECTRIC");
   }
 

--- a/src/filter/simplify_html.rs
+++ b/src/filter/simplify_html.rs
@@ -37,7 +37,7 @@ impl FeedFilter for SimplifyHtmlFilter {
 
     for post in &mut posts {
       let link = post.link().unwrap_or("").to_string();
-      post.modify_body(|body| {
+      post.modify_bodies(|body| {
         if let Some(simplified) = simplify(body, &link) {
           *body = simplified;
         }

--- a/src/filter/simplify_html.rs
+++ b/src/filter/simplify_html.rs
@@ -37,11 +37,11 @@ impl FeedFilter for SimplifyHtmlFilter {
 
     for post in &mut posts {
       let link = post.link().unwrap_or("").to_string();
-      if let Some(description) = post.description_mut() {
-        if let Some(simplified) = simplify(description, &link) {
-          *description = simplified;
+      post.modify_body(|body| {
+        if let Some(simplified) = simplify(body, &link) {
+          *body = simplified;
         }
-      };
+      });
     }
 
     feed.set_posts(posts);


### PR DESCRIPTION
This PR clarifies the concept for "body" used in code and config.

Fixes https://github.com/shouya/rss-funnel/issues/95 and https://github.com/shouya/rss-funnel/issues/96.

## Motivation

Previously, I name a generic field in the code "description" to distinguish it from the title. For rss format it refers to the [`description` field](https://github.com/shouya/rss-funnel/blob/dc1efac19a96e06143b75e9495adb3f6b013a75f/src/feed.rs#L348) and for atom it refers to the [`content` field](https://github.com/shouya/rss-funnel/blob/dc1efac19a96e06143b75e9495adb3f6b013a75f/src/feed.rs#L368). The choice of the name and the selected fields are purely arbitrary based on the few example feeds I had in hand. Overall, it is supposed be the field that ultimately get displayed in rss feeder beneath the title.

In this PR I renamed the general term to "body". Unlike the old notion, a post can have multiple `body` fields. We need this if we want to handle all types of different fields that considered as body in the RSS reader. For example, if we consider all the body fields, then we can correctly filter posts matching certain keyword using the `keep_only` and `discard` filter (https://github.com/shouya/rss-funnel/issues/95).

In addition, some feeds do not use the typical body fields. On example is YouTube, who puts the video description in the `media:description` field under the `media:group` tag (https://github.com/shouya/rss-funnel/issues/92). And we hope to support filtering on this field as well.

## Implementation

First, I removed the single-field accessor for `Post.description` field.

Then I provided various APIs for accessing the bodies:

  + `Post.bodies_mut`
  + `Post.bodies`
  + `Post.modify_bodies`
  + `Post.first_body`
  + `Post.first_body_mut`
  + `Post.create_body`
  + `Post.ensure_body`

The following fields are considered as body fields:

- rss
  + `content`
  + `description`
  + `media:description`
  + `itunes:summary`
- atom
  + `content`
  + `summary`
  + `media:description`

## Config changes

- Rename the `content` variant to `body` of the `field` field for `keep_only`/`discard` filter.
- Rename the `description_selector` field to `body_selector` for the `extract` filter.

Both changes are backward compatible. The old fields are currently marked deprecated, and may be removed in a future breaking release.

## Checklist

- [ ] update filter docs
- [x] review all usage of the term "description" in code