### PR TITLE
feat: proxy support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1697,6 +1697,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-socks",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -2351,6 +2352,18 @@ checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
  "rustls",
  "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51165dfa029d2a65969413a6cc96f354b86b464498702f174a4efa13608fd8c0"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ serde_json = "1.0.114" # for data transfer with the JS runtime
 either = "1.10.0" # used for returning sum types from the JS runtime
 
 # Web client (blocking and async both used, blocking used in the JS runtime)
-reqwest = { version = "0.12.2", default-features = false, features = ["blocking", "rustls-tls", "trust-dns"] }
+reqwest = { version = "0.12.2", default-features = false, features = ["blocking", "rustls-tls", "trust-dns", "socks"] }
 encoding_rs = "0.8.33"
 lru = "0.12.3"
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -43,6 +43,9 @@ pub enum ConfigError {
   #[error("Js runtime initialization error: {0}")]
   Js(#[from] JsError),
 
+  #[error("Client config error - bad header value: {0}")]
+  ClientHeader(#[from] reqwest::header::InvalidHeaderValue),
+
   #[error("Duplicate endpoint: {0}")]
   DuplicateEndpoint(String),
 


### PR DESCRIPTION
This PR adds the `proxy` field to client config which specifies the proxy to use for any HTTP requests. The format of the value is the same as the `all_proxy` environment (see https://docs.rs/reqwest/latest/reqwest/struct.Proxy.html).

This PR contains new config fields. Documentation updated accordingly.