### PR TITLE
feat: improve post body rendering on Web UI

### DIFF
--- a/inspector/src/FeedInspector.js
+++ b/inspector/src/FeedInspector.js
@@ -244,14 +244,14 @@ export class FeedInspector {
     });
   }
 
-  async render_feed_rendered({ structured }) {
+  async render_feed_rendered({ unified }) {
     $("#feed-preview #rendered").innerHTML = "";
-    const title_node = elt("h2", { class: "feed-title" }, structured.title);
+    const title_node = elt("h2", { class: "feed-title" }, unified.title);
     $("#feed-preview #rendered").appendChild(title_node);
 
     const sanitizer = new HtmlSanitizer({});
 
-    for (const post of structured.posts) {
+    for (const post of unified.posts) {
       const post_content = elt("p", { class: "feed-post-content" }, []);
       post_content.innerHTML = sanitizer.sanitizeHtml(post.body || "");
       const post_node = elt("div", { class: "feed-post" }, [
@@ -483,39 +483,4 @@ export class FeedInspector {
     setTimeout(() => (node.style.opacity = 0), 3000);
     setTimeout(() => node.remove(), 4000);
   }
-}
-
-// return {title: string, posts: [post]}
-// post: {title: string, link: string, date: string, content: string}
-function parse_feed(xml) {
-  const parser = new DOMParser();
-  const doc = parser.parseFromString(xml, "text/xml");
-
-  if (doc.documentElement.tagName == "rss") {
-    const title = doc.querySelector("channel > title").textContent.trim();
-    const posts = Array.from(doc.querySelectorAll("item")).map((item) => {
-      return {
-        title: item.querySelector("title")?.textContent?.trim(),
-        link: item.querySelector("link")?.textContent?.trim(),
-        date: item.querySelector("pubDate")?.textContent?.trim(),
-        content: item.querySelector("description")?.textContent?.trim(),
-      };
-    });
-
-    return { title, posts };
-  } else if (doc.documentElement.tagName == "feed") {
-    const title = doc.querySelector("feed > title").textContent.trim();
-    const posts = Array.from(doc.querySelectorAll("entry")).map((entry) => {
-      return {
-        title: entry.querySelector("title")?.textContent?.trim(),
-        link: entry.querySelector("link")?.getAttribute("href"),
-        date: entry.querySelector("published")?.textContent?.trim(),
-        content: entry.querySelector("content")?.textContent?.trim(),
-      };
-    });
-
-    return { title, posts };
-  }
-
-  return null;
 }

--- a/inspector/src/FeedInspector.js
+++ b/inspector/src/FeedInspector.js
@@ -246,22 +246,43 @@ export class FeedInspector {
 
   async render_feed_rendered({ unified }) {
     $("#feed-preview #rendered").innerHTML = "";
-    const title_node = elt("h2", { class: "feed-title" }, unified.title);
+    const title_node = elt(
+      "h3",
+      { class: "feed-title" },
+      elt("a", { href: unified.link }, unified.title),
+    );
+    const description_node = elt(
+      "div",
+      { class: "feed-description" },
+      unified.description,
+    );
+
     $("#feed-preview #rendered").appendChild(title_node);
+    $("#feed-preview #rendered").appendChild(description_node);
 
     const sanitizer = new HtmlSanitizer({});
 
     for (const post of unified.posts) {
-      const post_content = elt("p", { class: "feed-post-content" }, []);
-      post_content.innerHTML = sanitizer.sanitizeHtml(post.body || "");
+      const post_body = elt("div", { class: "feed-post-body" }, []);
+      post_body.innerHTML = sanitizer.sanitizeHtml(post.body || "");
+
+      let expand = elt("span", { class: "feed-post-show-all" }, "(expand)");
+      expand.addEventListener("click", (e) => {
+        post_body.classList.toggle("expanded");
+        expand.innerText = post_body.classList.contains("expanded")
+          ? "(collapse)"
+          : "(expand)";
+      });
+
       const post_node = elt("div", { class: "feed-post" }, [
         elt(
           "h3",
           { class: "feed-post-title" },
           elt("a", { class: "feed-post-link", href: post.link }, post.title),
         ),
-        post_content,
-        elt("p", { class: "feed-post-date" }, post.date),
+        elt("div", { class: "feed-post-date" }, post.date),
+        post_body,
+        expand,
       ]);
       $("#feed-preview #rendered").appendChild(post_node);
     }

--- a/inspector/src/FeedInspector.js
+++ b/inspector/src/FeedInspector.js
@@ -17,9 +17,8 @@ export class FeedInspector {
     this.filter_schema = null;
     this.current_endpoint = null;
     this.raw_editor = null;
-    this.raw_feed_content = null;
     this.json_preview_editor = null;
-    this.json_preview_content = null;
+    this.preview = null;
   }
 
   async init() {
@@ -237,30 +236,24 @@ export class FeedInspector {
         $(`#feed-preview #${mode}`).classList.add("hidden");
       }
 
-      const raw_feed_xml_xml = this.raw_feed_content;
+      const preview = this.preview;
       const function_name = `render_feed_${mode}`;
       if (this[function_name]) {
-        this[function_name](raw_feed_xml_xml);
+        this[function_name](preview);
       }
     });
   }
 
-  async render_feed_rendered(raw_feed_xml_xml) {
-    const parsed = parse_feed(raw_feed_xml_xml);
-    if (!parsed) {
-      console.error("Failed to parse feed");
-      return;
-    }
-
+  async render_feed_rendered({ structured }) {
     $("#feed-preview #rendered").innerHTML = "";
-    const title_node = elt("h2", { class: "feed-title" }, parsed.title);
+    const title_node = elt("h2", { class: "feed-title" }, structured.title);
     $("#feed-preview #rendered").appendChild(title_node);
 
     const sanitizer = new HtmlSanitizer({});
 
-    for (const post of parsed.posts) {
+    for (const post of structured.posts) {
       const post_content = elt("p", { class: "feed-post-content" }, []);
-      post_content.innerHTML = sanitizer.sanitizeHtml(post.content || "");
+      post_content.innerHTML = sanitizer.sanitizeHtml(post.body || "");
       const post_node = elt("div", { class: "feed-post" }, [
         elt(
           "h3",
@@ -274,21 +267,21 @@ export class FeedInspector {
     }
   }
 
-  async render_feed_raw(raw_feed_xml_xml) {
-    if (this.raw_editor.state.doc.toString() === raw_feed_xml_xml) {
+  async render_feed_raw({ raw }) {
+    if (this.raw_editor.state.doc.toString() === raw) {
       return;
     }
     this.raw_editor.dispatch({
       changes: {
         from: 0,
         to: this.raw_editor.state.doc.length,
-        insert: raw_feed_xml_xml,
+        insert: raw,
       },
     });
   }
 
-  async render_feed_json(_unused) {
-    const json = JSON.stringify(this.json_preview_content, null, 2);
+  async render_feed_json({ json }) {
+    json = JSON.stringify(json, null, 2);
     if (this.json_preview_editor.state.doc.toString() === json) {
       return;
     }
@@ -424,15 +417,13 @@ export class FeedInspector {
     let status_text = "";
 
     if (resp.status != 200) {
-      status_text = `Failed fetching ${path}`;
-      status_text += ` (status: ${resp.status} ${resp.statusText})`;
+      status_text = `Failed fetching ${path} (status: ${resp.status} ${resp.statusText})`;
       this.update_feed_error(await resp.text());
     } else {
       this.update_feed_error(null);
       const preview = await resp.json();
-      this.raw_feed_content = preview.content;
-      this.json_preview_content = preview.json;
-      status_text = `Fetched ${path} (${preview.content_type})`;
+      this.preview = preview;
+      status_text = `Fetched feed with ${preview.post_count} posts from ${path} (${preview.content_type})`;
     }
 
     status_text += ` in ${performance.now() - time_start}ms.`;

--- a/inspector/src/style.css
+++ b/inspector/src/style.css
@@ -445,21 +445,53 @@ ul#filter-list {
   .feed-title {
     margin: 0;
     padding: 0.5rem;
-    width: 100%;
-    background-color: #fff;
+  }
+
+  .feed-description {
+    padding: 0.5rem;
+    font-size: 0.9em;
   }
 
   .feed-post {
-    padding: 0.5rem;
+    padding: 0.8rem;
+    border-radius: 0.5rem;
     border: 1px solid #ddd;
-    border-radius: 0.3rem;
     background-color: #fafafa;
+    max-width: 90%;
+    margin: 0.5rem 0.5rem;
+
+    .feed-post-show-all {
+      cursor: pointer;
+      font-size: 0.8em;
+      margin-right: 0.5rem;
+      color: #666;
+    }
 
     .feed-post-title {
       margin: 0;
+    }
+
+    .feed-post-date {
+      font-size: 0.9em;
+      color: #666;
+      margin-top: 0.6rem;
       padding-bottom: 0.5rem;
-      font-size: 1.2em;
       border-bottom: 1px solid #ddd;
+    }
+
+    .feed-post-body {
+      padding: 1rem;
+      font-size: 0.9rem;
+      max-height: 20rem;
+      overflow-y: scroll;
+
+      img {
+        max-width: 100%;
+      }
+    }
+
+    .feed-post-body.expanded {
+      max-height: initial;
     }
   }
 }

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -313,7 +313,7 @@ impl From<&FromScratch> for Feed {
 
 // Generic field accessors
 impl Feed {
-  fn title(&self) -> &str {
+  pub fn title(&self) -> &str {
     match self {
       Feed::Rss(channel) => &channel.title,
       Feed::Atom(feed) => feed.title.as_str(),

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -366,7 +366,7 @@ impl Post {
       author,
       link,
       body,
-      published,
+      date: published,
     }
   }
   pub fn set_pub_date(&mut self, date: DateTime<chrono::FixedOffset>) {

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -42,6 +42,13 @@ impl Feed {
     }
   }
 
+  pub fn post_count(&self) -> usize {
+    match self {
+      Feed::Rss(channel) => channel.items.len(),
+      Feed::Atom(feed) => feed.entries.len(),
+    }
+  }
+
   pub fn into_format(self, format: FeedFormat) -> Self {
     use conversion::W;
 

--- a/src/feed/preview.rs
+++ b/src/feed/preview.rs
@@ -15,5 +15,5 @@ pub struct PostPreview {
   pub author: Option<String>,
   pub link: String,
   pub body: Option<String>,
-  pub published: Option<DateTime<FixedOffset>>,
+  pub date: Option<DateTime<FixedOffset>>,
 }

--- a/src/feed/preview.rs
+++ b/src/feed/preview.rs
@@ -1,0 +1,19 @@
+use chrono::{DateTime, FixedOffset};
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct FeedPreview {
+  title: String,
+  link: String,
+  description: Option<String>,
+  posts: Vec<PostPreview>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PostPreview {
+  title: String,
+  author: Option<String>,
+  link: String,
+  body: String,
+  published: DateTime<FixedOffset>,
+}

--- a/src/feed/preview.rs
+++ b/src/feed/preview.rs
@@ -3,17 +3,17 @@ use serde::Serialize;
 
 #[derive(Debug, Serialize)]
 pub struct FeedPreview {
-  title: String,
-  link: String,
-  description: Option<String>,
-  posts: Vec<PostPreview>,
+  pub title: String,
+  pub link: String,
+  pub description: Option<String>,
+  pub posts: Vec<PostPreview>,
 }
 
 #[derive(Debug, Serialize)]
 pub struct PostPreview {
-  title: String,
-  author: Option<String>,
-  link: String,
-  body: String,
-  published: DateTime<FixedOffset>,
+  pub title: String,
+  pub author: Option<String>,
+  pub link: String,
+  pub body: Option<String>,
+  pub published: Option<DateTime<FixedOffset>>,
 }

--- a/src/server/inspector.rs
+++ b/src/server/inspector.rs
@@ -143,7 +143,7 @@ async fn preview_handler(
   let body = json!({
     "content_type": feed.content_type(),
     "post_count": feed.post_count(),
-    "structured": feed.preview(),
+    "unified": feed.preview(),
     "raw": feed.serialize(true)?,
     "json": feed
   });

--- a/src/server/inspector.rs
+++ b/src/server/inspector.rs
@@ -142,6 +142,7 @@ async fn preview_handler(
   let feed = endpoint_service.run(endpoint_param).await?;
   let body = json!({
     "content_type": feed.content_type(),
+    "count": feed.post_count(),
     "content": feed.serialize(true)?,
     "json": feed
   });

--- a/src/server/inspector.rs
+++ b/src/server/inspector.rs
@@ -142,8 +142,9 @@ async fn preview_handler(
   let feed = endpoint_service.run(endpoint_param).await?;
   let body = json!({
     "content_type": feed.content_type(),
-    "count": feed.post_count(),
-    "content": feed.serialize(true)?,
+    "post_count": feed.post_count(),
+    "structured": feed.preview(),
+    "raw": feed.serialize(true)?,
     "json": feed
   });
   Ok(Json(body))


### PR DESCRIPTION
Previously, the "Rendered" view was parsed from the raw XML feed on the front-end. The logic on determining which field to show as posts' bodies is arbitrary. Since #100, I changed the logic to recognize more post body types. However, such change was not reflected on the Web UI. This PR updates the Web UI to show the expected body content.

Besides, I made some visual tweaks to the Rendered view to show more information including post's publication date, feed's description, etc.

In addition, The status bar will now show the number of posts on successful fetches.