### PR TITLE
feat(js): add more utility functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1670,7 +1676,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d66674f2b6fb864665eea7a3c1ac4e3dfacd2fda83cf6f935a612e01b0e3338"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -1794,6 +1800,7 @@ dependencies = [
  "axum",
  "axum-extra",
  "axum-macros",
+ "base64 0.22.0",
  "chrono",
  "clap",
  "duration-str",
@@ -1902,7 +1909,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+ "base64 0.21.7",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1836,6 +1836,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "urlencoding",
 ]
 
 [[package]]
@@ -2579,6 +2580,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ regex = "1.10.3"
 tracing = { version = "0.1.40"}
 tracing-subscriber = "0.3.18"
 axum-extra = { version = "0.9.2", features = ["cookie"] }
+base64 = "0.22.0"
 
 [patch.crates-io]
 ego-tree = { git = "https://github.com/shouya/ego-tree.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ tracing = { version = "0.1.40"}
 tracing-subscriber = "0.3.18"
 axum-extra = { version = "0.9.2", features = ["cookie"] }
 base64 = "0.22.0"
+urlencoding = "2.1.3"
 
 [patch.crates-io]
 ego-tree = { git = "https://github.com/shouya/ego-tree.git" }

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -281,10 +281,10 @@ impl From<&FromScratch> for Feed {
         };
 
         if let Some(link) = &config.link {
-          channel.link = link.clone();
+          channel.link.clone_from(link);
         }
         if let Some(description) = &config.description {
-          channel.description = description.clone();
+          channel.description.clone_from(description);
         }
 
         Feed::Rss(channel)

--- a/src/feed/conversion.rs
+++ b/src/feed/conversion.rs
@@ -103,7 +103,7 @@ impl From<W<rss::Channel>> for atom_syndication::Feed {
     let mut feed = Self::default();
 
     feed.title = channel.title.into();
-    feed.id = channel.link.clone();
+    feed.id.clone_from(&channel.link);
 
     // Updated - using last_build_date if available, otherwise pub_date
     feed.updated = channel
@@ -174,14 +174,18 @@ impl From<W<atom_syndication::Feed>> for rss::Channel {
   fn from(W(feed): W<atom_syndication::Feed>) -> Self {
     let mut channel = Self::default();
 
-    channel.title = feed.title.as_str().to_owned();
+    feed.title.as_str().clone_into(&mut channel.title);
     channel.link = feed
       .links
       .into_iter()
       .next()
       .map_or_else(String::default, |l| l.href);
-    channel.description =
-      feed.subtitle.as_deref().unwrap_or_default().to_owned();
+    feed
+      .subtitle
+      .as_deref()
+      .unwrap_or_default()
+      .clone_into(&mut channel.description);
+
     if feed.updated.timestamp() != 0 {
       channel.last_build_date = Some(feed.updated.to_rfc2822());
     }

--- a/src/js/builtin.rs
+++ b/src/js/builtin.rs
@@ -1,3 +1,4 @@
+use base64::prelude::{Engine as _, BASE64_STANDARD};
 use rquickjs::{
   class::Trace,
   function::{Async, Func},
@@ -65,5 +66,13 @@ impl Util {
 
   fn encode_html(html: String) -> String {
     htmlescape::encode_minimal(&html)
+  }
+
+  fn decode_base64(base64: String) -> Option<Vec<u8>> {
+    BASE64_STANDARD.decode(base64).ok()
+  }
+
+  fn encode_base64(bytes: Vec<u8>) -> String {
+    BASE64_STANDARD.encode(&bytes)
   }
 }

--- a/src/js/builtin.rs
+++ b/src/js/builtin.rs
@@ -73,6 +73,14 @@ impl Util {
   }
 
   fn encode_base64(bytes: Vec<u8>) -> String {
-    BASE64_STANDARD.encode(&bytes)
+    BASE64_STANDARD.encode(bytes)
+  }
+
+  fn encode_url(url: String) -> String {
+    urlencoding::encode(&url).to_string()
+  }
+
+  fn decode_url(url: String) -> Option<String> {
+    urlencoding::decode(&url).ok().map(|s| s.to_string())
   }
 }

--- a/src/js/builtin.rs
+++ b/src/js/builtin.rs
@@ -68,11 +68,12 @@ impl Util {
     htmlescape::encode_minimal(&html)
   }
 
-  fn decode_base64(base64: String) -> Option<Vec<u8>> {
-    BASE64_STANDARD.decode(base64).ok()
+  fn decode_base64(base64: String) -> Option<String> {
+    let bytes = BASE64_STANDARD.decode(base64).ok()?;
+    String::from_utf8(bytes).ok()
   }
 
-  fn encode_base64(bytes: Vec<u8>) -> String {
+  fn encode_base64(bytes: String) -> String {
     BASE64_STANDARD.encode(bytes)
   }
 


### PR DESCRIPTION
This PR adds four new functions to the JavaScript runtime.

- `util.encode_url(string): string`
- `util.decode_url(string): string?`
- `util.encode_base64(string): string`
- `util.decode_base64(string): string?`

These functions are available in js filters including `filter_post`, `filter_feed`, and `js`.