### PR TITLE
updates to make work build on target arm-unknown-linux-gnueabihf

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["command-line-interface", "web-programming"]
 [features]
 default = ["inspector-ui"]
 inspector-ui = ["dep:rust-embed"]
+bindgen = ["rquickjs/bindgen"]
 
 [dependencies]
 # Async runtime, utility and helper crates
@@ -60,7 +61,7 @@ html5ever = "0.26.0"
 htmlescape = "0.3.1"
 
 # JS runtime crates
-rquickjs = { version = "0.5.1", features = ["loader", "parallel", "macro", "futures", "exports", "either", "bindgen"] }
+rquickjs = { version = "0.5.1", features = ["loader", "parallel", "macro", "futures", "exports", "either"] }
 serde_json = "1.0.114" # for data transfer with the JS runtime
 either = "1.10.0" # used for returning sum types from the JS runtime
 

--- a/Cross.toml
+++ b/Cross.toml
@@ -6,5 +6,5 @@ pre-build = ["apt-get update && apt-get install -y clang patch"]
 
 [target.arm-unknown-linux-gnueabihf]
 # https://github.com/bellard/quickjs/issues/75
-pre-build = ["apt-get update && apt-get install -y clang patch libc6-dev "]
+pre-build = ["apt-get update && apt-get install -y clang patch libc6-dev"]
 env.passthrough = ["RUSTFLAGS=-Clink-arg=-latomic"]

--- a/Cross.toml
+++ b/Cross.toml
@@ -5,6 +5,6 @@ pre-build = ["apt-get update && apt-get install -y clang"]
 pre-build = ["apt-get update && apt-get install -y clang patch"]
 
 [target.arm-unknown-linux-gnueabihf]
-dockerfile = "Dockerfile.armhf"
 # https://github.com/bellard/quickjs/issues/75
+pre-build = ["apt-get update && apt-get install -y clang patch libc6-dev "]
 env.passthrough = ["RUSTFLAGS=-Clink-arg=-latomic"]

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,9 +1,0 @@
-FROM docker.io/dockcross/linux-armv6 AS BINARY_SRC_IMG
-
-ARG CROSS_BASE_IMAGE
-FROM $CROSS_BASE_IMAGE
-
-# patch is needed by rquickjs bindgen. However, apt armhf packages are
-# for armv7, so we simply steal the binary from the an unrelated
-# image.
-COPY --from=BINARY_SRC_IMG /usr/bin/patch /usr/bin/patch

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,10 @@ target/aarch64-unknown-linux-musl/release/$(APP_NAME): $(SOURCES) inspector-asse
 	cargo clean
 	cross build --release --target aarch64-unknown-linux-musl
 
+target/arm-unknown-linux-gnueabihf/release/$(APP_NAME): $(SOURCES) inspector-assets
+	cargo clean
+	cross build --release --target arm-unknown-linux-gnueabihf --features bindgen
+
 $(IMAGE_NAME)\:latest-% $(IMAGE_NAME)\:nightly-%: $(IMAGE_NAME)\:$(VERSION)-%
 	podman tag $< $@
 


### PR DESCRIPTION
fix for https://github.com/shouya/rss-funnel/pull/110
build for armv6-hf

with these changes command 
```
cross build -r --target arm-unknown-linux-gnueabihf
```
works and it runs, but the web part (GUI) doesn't work. But it is not a problem.