### PR TITLE
Cache feed results after full_text filter

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -12,7 +12,7 @@ pub struct Timed<T> {
   created: Instant,
 }
 
-pub struct ResultCache<K, V> {
+pub struct ResultCache<K: Hash + Eq, V: Clone> {
   map: RwLock<LruCache<K, Timed<V>>>,
   timeout: Duration,
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,47 @@
+use std::{
+  hash::Hash,
+  num::NonZeroUsize,
+  sync::RwLock,
+  time::{Duration, Instant},
+};
+
+use lru::LruCache;
+
+pub struct Timed<T> {
+  value: T,
+  created: Instant,
+}
+
+pub struct ResultCache<K, V> {
+  map: RwLock<LruCache<K, Timed<V>>>,
+  timeout: Duration,
+}
+
+impl<K: Hash + Eq, V: Clone> ResultCache<K, V> {
+  pub fn new(max_entries: usize, timeout: Duration) -> Self {
+    let max_entries = max_entries.try_into().unwrap_or(NonZeroUsize::MIN);
+    Self {
+      map: RwLock::new(LruCache::new(max_entries)),
+      timeout,
+    }
+  }
+
+  pub fn get_cached(&self, key: &K) -> Option<V> {
+    let mut map = self.map.write().ok()?;
+    let entry = map.get(key)?;
+    if entry.created.elapsed() > self.timeout {
+      map.pop(key);
+      return None;
+    }
+    Some(entry.value.clone())
+  }
+
+  pub fn insert(&self, key: K, value: V) -> Option<()> {
+    let timed = Timed {
+      value,
+      created: Instant::now(),
+    };
+    self.map.write().ok()?.push(key, timed);
+    Some(())
+  }
+}

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -12,12 +12,12 @@ pub struct Timed<T> {
   created: Instant,
 }
 
-pub struct ResultCache<K: Hash + Eq, V: Clone> {
+pub struct TimedLruCache<K: Hash + Eq, V: Clone> {
   map: RwLock<LruCache<K, Timed<V>>>,
   timeout: Duration,
 }
 
-impl<K: Hash + Eq, V: Clone> ResultCache<K, V> {
+impl<K: Hash + Eq, V: Clone> TimedLruCache<K, V> {
   pub fn new(max_entries: usize, timeout: Duration) -> Self {
     let max_entries = max_entries.try_into().unwrap_or(NonZeroUsize::MIN);
     Self {

--- a/src/client.rs
+++ b/src/client.rs
@@ -57,6 +57,13 @@ pub struct ClientConfig {
 }
 
 impl ClientConfig {
+  pub fn get_cache_size(&self) -> usize {
+    self.cache_size.unwrap_or(64)
+  }
+  pub fn get_cache_ttl(&self, default_cache_ttl: Duration) -> Duration {
+    self.cache_ttl.unwrap_or(default_cache_ttl)
+  }
+
   fn to_builder(&self) -> Result<reqwest::ClientBuilder, ConfigError> {
     let mut builder = reqwest::Client::builder();
 
@@ -99,8 +106,8 @@ impl ClientConfig {
   ) -> Result<Client, ConfigError> {
     let reqwest_client = self.to_builder()?.build()?;
     let client = Client::new(
-      self.cache_size.unwrap_or(64),
-      self.cache_ttl.unwrap_or(default_cache_ttl),
+      self.get_cache_size(),
+      self.get_cache_ttl(default_cache_ttl),
       reqwest_client,
       self.assume_content_type.clone(),
     );

--- a/src/client/cache.rs
+++ b/src/client/cache.rs
@@ -1,54 +1,14 @@
-use std::{
-  num::NonZeroUsize,
-  sync::{Arc, RwLock},
-  time::{Duration, Instant},
-};
+use std::sync::Arc;
 
-use lru::LruCache;
+use crate::cache::ResultCache;
+
 use mime::Mime;
 use reqwest::header::HeaderMap;
 use url::Url;
 
 use crate::util::{Error, Result};
 
-struct Timed<T> {
-  value: T,
-  created: Instant,
-}
-
-pub struct ResponseCache {
-  map: RwLock<LruCache<Url, Timed<Response>>>,
-  timeout: Duration,
-}
-
-impl ResponseCache {
-  pub fn new(max_entries: usize, timeout: Duration) -> Self {
-    let max_entries = max_entries.try_into().unwrap_or(NonZeroUsize::MIN);
-    Self {
-      map: RwLock::new(LruCache::new(max_entries)),
-      timeout,
-    }
-  }
-
-  pub fn get_cached(&self, url: &Url) -> Option<Response> {
-    let mut map = self.map.write().ok()?;
-    let entry = map.get(url)?;
-    if entry.created.elapsed() > self.timeout {
-      map.pop(url);
-      return None;
-    }
-    Some(entry.value.clone())
-  }
-
-  pub fn insert(&self, url: Url, response: Response) -> Option<()> {
-    let timed = Timed {
-      value: response,
-      created: Instant::now(),
-    };
-    self.map.write().ok()?.push(url, timed);
-    Some(())
-  }
-}
+pub type ResponseCache = ResultCache<Url, Response>;
 
 #[derive(Clone)]
 pub struct Response {

--- a/src/client/cache.rs
+++ b/src/client/cache.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::cache::ResultCache;
+use crate::cache::TimedLruCache;
 
 use mime::Mime;
 use reqwest::header::HeaderMap;
@@ -8,7 +8,7 @@ use url::Url;
 
 use crate::util::{Error, Result};
 
-pub type ResponseCache = ResultCache<Url, Response>;
+pub type ResponseCache = TimedLruCache<Url, Response>;
 
 #[derive(Clone)]
 pub struct Response {

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -20,7 +20,7 @@ use crate::util::Result;
 use extension::ExtensionExt;
 
 use self::preview::FeedPreview;
-use self::preview::PostPreview;
+pub use self::preview::PostPreview;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(untagged)]
@@ -346,19 +346,6 @@ impl Feed {
 pub enum Post {
   Rss(rss::Item),
   Atom(atom_syndication::Entry),
-}
-
-impl Eq for Post {}
-impl PartialEq for Post {
-  fn eq(&self, other: &Self) -> bool {
-    self.preview() == other.preview()
-  }
-}
-
-impl Hash for Post {
-  fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-    self.preview().hash(state);
-  }
 }
 
 enum PostField {

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -2,6 +2,8 @@ mod conversion;
 mod extension;
 mod preview;
 
+use std::hash::Hash;
+
 use chrono::DateTime;
 use paste::paste;
 use schemars::JsonSchema;
@@ -344,6 +346,19 @@ impl Feed {
 pub enum Post {
   Rss(rss::Item),
   Atom(atom_syndication::Entry),
+}
+
+impl Eq for Post {}
+impl PartialEq for Post {
+  fn eq(&self, other: &Self) -> bool {
+    self.preview() == other.preview()
+  }
+}
+
+impl Hash for Post {
+  fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+    self.preview().hash(state);
+  }
 }
 
 enum PostField {

--- a/src/feed/preview.rs
+++ b/src/feed/preview.rs
@@ -9,7 +9,7 @@ pub struct FeedPreview {
   pub posts: Vec<PostPreview>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, PartialEq, Eq, Hash)]
 pub struct PostPreview {
   pub title: String,
   pub author: Option<String>,

--- a/src/filter/full_text.rs
+++ b/src/filter/full_text.rs
@@ -7,6 +7,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
+use crate::cache::ResultCache;
 use crate::client::{self, Client};
 use crate::feed::{Feed, Post};
 use crate::html::convert_relative_url;
@@ -14,6 +15,8 @@ use crate::util::{ConfigError, Error, Result};
 
 use super::html::{KeepElement, KeepElementConfig};
 use super::{FeedFilter, FeedFilterConfig, FilterContext};
+
+type PostCache = ResultCache<Post, Post>;
 
 const DEFAULT_PARALLELISM: usize = 20;
 
@@ -42,6 +45,7 @@ pub struct FullTextFilter {
   keep_element: Option<KeepElement>,
   simplify: bool,
   keep_guid: bool,
+  post_cache: PostCache,
 }
 
 #[async_trait::async_trait]
@@ -51,7 +55,8 @@ impl FeedFilterConfig for FullTextConfig {
   async fn build(self) -> Result<Self::Filter, ConfigError> {
     // default cache ttl is 12 hours
     let default_cache_ttl = Duration::from_secs(12 * 60 * 60);
-    let client = self.client.unwrap_or_default().build(default_cache_ttl)?;
+    let conf_client = self.client.unwrap_or_default();
+    let client = conf_client.build(default_cache_ttl)?;
     let parallelism = self.parallelism.unwrap_or(DEFAULT_PARALLELISM);
     let append_mode = self.append_mode.unwrap_or(false);
     let simplify = self.simplify.unwrap_or(false);
@@ -60,6 +65,10 @@ impl FeedFilterConfig for FullTextConfig {
       None => None,
       Some(c) => Some(c.build().await?),
     };
+    let post_cache = PostCache::new(
+      conf_client.get_cache_size(),
+      conf_client.get_cache_ttl(default_cache_ttl),
+    );
 
     Ok(FullTextFilter {
       simplify,
@@ -68,6 +77,7 @@ impl FeedFilterConfig for FullTextConfig {
       append_mode,
       keep_guid,
       keep_element,
+      post_cache,
     })
   }
 }
@@ -142,7 +152,19 @@ impl FullTextFilter {
 
   async fn fetch_all_posts(&self, posts: Vec<Post>) -> Result<Vec<Post>> {
     stream::iter(posts)
-      .map(|post| self.fetch_full_post(post))
+      .map(|post| async {
+        if let Some(result_post) = self.post_cache.get_cached(&post) {
+          return Ok(result_post);
+        };
+
+        match self.fetch_full_post(post.clone()).await {
+          Ok(result_post) => {
+            self.post_cache.insert(post, result_post.clone());
+            Ok(result_post)
+          }
+          Err(e) => Err(e),
+        }
+      })
       .buffered(self.parallelism)
       .collect::<Vec<_>>()
       .await

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod cache;
 mod cli;
 mod client;
 mod config;


### PR DESCRIPTION
Added cache feed results after full_text filter.
It allows avoid calling try_fetch_full_post twice for the same post. So performance of application is increased from 10s to 1s on my Raspberry Pi. I think it is a huge impact.
