### PR TITLE
fix(client): Fix broken cookie in requests

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -75,10 +75,8 @@ impl ClientConfig {
 
     if let Some(cookie) = &self.cookie {
       header_map.append("Cookie", cookie.try_into()?);
-    } else {
-      if let Some(set_cookie) = &self.set_cookie {
-        header_map.append("Cookie", set_cookie.try_into()?);
-      }
+    } else if let Some(set_cookie) = &self.set_cookie {
+      header_map.append("Cookie", set_cookie.try_into()?);
     }
 
     if let Some(referer) = &self.referer {

--- a/src/client.rs
+++ b/src/client.rs
@@ -30,8 +30,10 @@ pub struct ClientConfig {
   user_agent: Option<String>,
   /// The "accept" header to send with requests
   accept: Option<String>,
-  /// The "set-cookie" header to send with requests
+  /// The "cookie" header to send with requests (Deprecated, specify "cookie" field instead)
   set_cookie: Option<String>,
+  /// The "cookie" header to send with requests
+  cookie: Option<String>,
   /// The "referer" header to send with requests
   referer: Option<String>,
   /// The maximum number of cached responses
@@ -71,8 +73,12 @@ impl ClientConfig {
       header_map.append("Accept", accept.try_into()?);
     }
 
-    if let Some(set_cookie) = &self.set_cookie {
-      header_map.append("Set-Cookie", set_cookie.try_into()?);
+    if let Some(cookie) = &self.cookie {
+      header_map.append("Cookie", cookie.try_into()?);
+    } else {
+      if let Some(set_cookie) = &self.set_cookie {
+        header_map.append("Cookie", set_cookie.try_into()?);
+      }
     }
 
     if let Some(referer) = &self.referer {

--- a/src/feed/extension.rs
+++ b/src/feed/extension.rs
@@ -2,12 +2,14 @@ use std::collections::BTreeMap;
 
 pub struct TagRef<'a> {
   pub name: &'a String,
+  #[allow(dead_code)]
   pub attrs: &'a BTreeMap<String, String>,
   pub value: &'a Option<String>,
 }
 
 pub struct TagRefMut<'a> {
   pub name: &'a mut String,
+  #[allow(dead_code)]
   pub attrs: &'a mut BTreeMap<String, String>,
   pub value: &'a mut Option<String>,
 }

--- a/src/js.rs
+++ b/src/js.rs
@@ -313,6 +313,8 @@ pub struct Exception {
   pub file: Option<String>,
   pub line: Option<i32>,
   pub column: Option<i32>,
+  // captured but unused yet
+  #[allow(dead_code)]
   pub stack: Option<String>,
   pub source: Option<String>,
 }


### PR DESCRIPTION
I renamed the `set_cookie` field to `cookie` in the `Request` struct. The old field is now deprecated and will be removed in the next release.