### PR TITLE
feat(client): support http/2 requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1787,6 +1787,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -2018,9 +2019,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99008d7ad0bbbea527ec27bddbc0e432c5b87d8175178cee68d2eec9c4a1813c"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
  "log",
  "ring",
@@ -2041,15 +2042,15 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.4.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.2"
+version = "0.102.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
+checksum = "f3bce581c0dd41bce533ce695a1437fa16a7ab5ac3ccfa99fe1a620a7885eabf"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ serde_json = "1.0.114" # for data transfer with the JS runtime
 either = "1.10.0" # used for returning sum types from the JS runtime
 
 # Web client (blocking and async both used, blocking used in the JS runtime)
-reqwest = { version = "0.12.2", default-features = false, features = ["blocking", "rustls-tls", "trust-dns", "socks"] }
+reqwest = { version = "0.12.2", default-features = false, features = ["blocking", "trust-dns", "socks", "http2", "rustls-tls"] }
 encoding_rs = "0.8.33"
 lru = "0.12.3"
 


### PR DESCRIPTION
This PR adds support for HTTP/2 requests that's enabled by default. The feature was added because I have a feed protected by cloudflare that triggers the anti-scraping page on HTTP/1.1 requests.

In addition, it's now possible to skip certificate verification by setting the `accepts_invalid_certs` option to `true`.