### PR TITLE
feat(filters): detect magnet links from feed entries

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,10 +1,10 @@
 mod convert;
-mod find_magnet;
 mod full_text;
 mod highlight;
 mod html;
 mod js;
 mod limit;
+mod magnet;
 mod merge;
 mod note;
 mod sanitize;
@@ -228,5 +228,5 @@ define_filters!(
   Note => note::NoteFilterConfig, "Add non-functional comment";
   ConvertTo => convert::ConvertToConfig, "Convert feed to another format";
   Limit => limit::LimitConfig, "Limit the number of posts";
-  FindMagnet => find_magnet::FindMagnetConfig, "Find magnet links in posts";
+  Magnet => magnet::MagnetConfig, "Find magnet links in posts";
 );

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,4 +1,5 @@
 mod convert;
+mod find_magnet;
 mod full_text;
 mod highlight;
 mod html;

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -228,4 +228,5 @@ define_filters!(
   Note => note::NoteFilterConfig, "Add non-functional comment";
   ConvertTo => convert::ConvertToConfig, "Convert feed to another format";
   Limit => limit::LimitConfig, "Limit the number of posts";
+  FindMagnet => find_magnet::FindMagnetConfig, "Find magnet links in posts";
 );

--- a/src/filter/find_magnet.rs
+++ b/src/filter/find_magnet.rs
@@ -1,0 +1,140 @@
+use regex::Regex;
+use rss::Enclosure;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+  feed::{Feed, Post},
+  util::{ConfigError, Error},
+};
+
+use super::{FeedFilter, FeedFilterConfig, FilterContext};
+
+#[derive(
+  JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
+)]
+/// Find magnet link discovered in the body of entries and save it in
+/// the enclosure (RSS)/link (Atom). The resulting feed can be used in
+/// a torrent client.
+pub struct FindMagnetConfig {
+  /// Match any `[a-fA-F0-9]{40}` as the info hash.
+  #[serde(default)]
+  info_hash: bool,
+  /// Whether or not to override existing magnet links in the enclosure/link.
+  #[serde(default)]
+  override_existing: bool,
+}
+
+pub struct FindMagnet {
+  config: FindMagnetConfig,
+}
+
+#[async_trait::async_trait]
+impl FeedFilterConfig for FindMagnetConfig {
+  type Filter = FindMagnet;
+
+  async fn build(self) -> Result<Self::Filter, ConfigError> {
+    Ok(FindMagnet { config: self })
+  }
+}
+
+#[async_trait::async_trait]
+impl FeedFilter for FindMagnet {
+  async fn run(
+    &self,
+    _ctx: &mut FilterContext,
+    mut feed: Feed,
+  ) -> Result<Feed, Error> {
+    let mut posts = feed.take_posts();
+
+    for post in posts.iter_mut() {
+      let bodies = post.bodies();
+      let link: Option<String> = bodies
+        .iter()
+        .flat_map(|body| find_magnet_links(body, &self.config))
+        .next();
+
+      if let Some(link) = link {
+        set_magnet_link(post, link, self.config.override_existing);
+      }
+    }
+
+    feed.set_posts(posts);
+    Ok(feed)
+  }
+}
+
+lazy_static::lazy_static! {
+  static ref MAGNET_LINK_REGEX: Regex = Regex::new(
+    r"(?i)\b(?P<full>magnet:\?xt=urn:btih:[a-fA-F0-9]{40}(&\w+=[^\s]+)*)\b"
+  )
+    .unwrap();
+  static ref INFO_HASH_REGEX: Regex =
+    Regex::new(r"\b(?i)(?P<info_hash>[a-fA-F0-9]{40})\b").unwrap();
+}
+
+fn existing_magnet_link(post: &Post) -> Option<&str> {
+  match post {
+    Post::Rss(p) => p
+      .enclosure()
+      .into_iter()
+      .filter(|e| e.mime_type() == "application/x-bittorrent")
+      .map(|e| e.url())
+      .next(),
+    Post::Atom(p) => p
+      .links()
+      .iter()
+      .filter(|l| l.href().starts_with("magnet:"))
+      .map(|l| l.href())
+      .next(),
+  }
+}
+
+fn set_magnet_link(post: &mut Post, link: String, override_: bool) {
+  if !override_ && existing_magnet_link(post).is_none() {
+    return;
+  }
+
+  match post {
+    Post::Rss(p) => {
+      let enclosure = Enclosure {
+        url: link,
+        mime_type: "application/x-bittorrent".to_string(),
+        length: "".to_string(),
+      };
+      p.set_enclosure(enclosure);
+    }
+    Post::Atom(p) => {
+      let link = atom_syndication::Link {
+        href: link,
+        mime_type: Some("application/x-bittorrent".to_string()),
+        ..Default::default()
+      };
+      p.links.push(link);
+    }
+  }
+}
+
+fn find_magnet_links(text: &str, config: &FindMagnetConfig) -> Vec<String> {
+  let regex = if config.info_hash {
+    &*INFO_HASH_REGEX
+  } else {
+    &*MAGNET_LINK_REGEX
+  };
+
+  let captures: Vec<regex::Captures> = regex.captures_iter(text).collect();
+
+  captures
+    .into_iter()
+    .map(|m| {
+      if config.info_hash {
+        format!(
+          "magnet:?xt=urn:btih:{}",
+          m.name("info_hash").unwrap().as_str()
+        )
+      } else {
+        m.name("full").unwrap().as_str().to_string()
+      }
+    })
+    .collect()
+}

--- a/src/filter/magnet.rs
+++ b/src/filter/magnet.rs
@@ -17,7 +17,7 @@ use super::{FeedFilter, FeedFilterConfig, FilterContext};
 /// Find magnet link discovered in the body of entries and save it in
 /// the enclosure (RSS)/link (Atom). The resulting feed can be used in
 /// a torrent client.
-pub struct FindMagnetConfig {
+pub struct MagnetConfig {
   /// Match any `[a-fA-F0-9]{40}` as the info hash.
   #[serde(default)]
   info_hash: bool,
@@ -26,21 +26,21 @@ pub struct FindMagnetConfig {
   override_existing: bool,
 }
 
-pub struct FindMagnet {
-  config: FindMagnetConfig,
+pub struct Magnet {
+  config: MagnetConfig,
 }
 
 #[async_trait::async_trait]
-impl FeedFilterConfig for FindMagnetConfig {
-  type Filter = FindMagnet;
+impl FeedFilterConfig for MagnetConfig {
+  type Filter = Magnet;
 
   async fn build(self) -> Result<Self::Filter, ConfigError> {
-    Ok(FindMagnet { config: self })
+    Ok(Magnet { config: self })
   }
 }
 
 #[async_trait::async_trait]
-impl FeedFilter for FindMagnet {
+impl FeedFilter for Magnet {
   async fn run(
     &self,
     _ctx: &mut FilterContext,
@@ -117,7 +117,7 @@ fn set_magnet_link(post: &mut Post, link: String, override_: bool) {
   }
 }
 
-fn find_magnet_links(text: &str, config: &FindMagnetConfig) -> Vec<String> {
+fn find_magnet_links(text: &str, config: &MagnetConfig) -> Vec<String> {
   let regex = if config.info_hash {
     &*INFO_HASH_REGEX
   } else {
@@ -153,7 +153,7 @@ mod test {
     let text = "HELLO magnet:?xt=urn:btih:1234567890ABCDEF1234567890ABCDEF12345678&dn=hello+world WORLD";
     let links = super::find_magnet_links(
       text,
-      &super::FindMagnetConfig {
+      &super::MagnetConfig {
         info_hash: false,
         override_existing: false,
       },
@@ -168,7 +168,7 @@ mod test {
     let text = "HELLO 1234567890ABCDEF1234567890ABCDEF12345678 WORLD";
     let links = super::find_magnet_links(
       text,
-      &super::FindMagnetConfig {
+      &super::MagnetConfig {
         info_hash: true,
         override_existing: false,
       },
@@ -181,7 +181,7 @@ mod test {
     let text = "HELLO 1234567890ABCDEF1234567890ABCDEF12345678 WORLD";
     let links = super::find_magnet_links(
       text,
-      &super::FindMagnetConfig {
+      &super::MagnetConfig {
         info_hash: false,
         override_existing: false,
       },


### PR DESCRIPTION
This PR adds a new filter `magnet` that extracts magnet links from the body of the feed entry and store them in places bittorrent clients recognizes.

For feeds in RSS format, the magnet links will be stored in the `<enclosure>`. For feeds in Atom format, the magnet links will be stored in a new `<link>`.

The filter has two configurations:

- `info_hash` (boolean, default: false): whether or not to detect info hash by length without `magnet:` prefix. It's used when the magnet link is not directly given in the body but the info hash is somehow extractable.
- `override_existing` (boolean, default: false): if the entry already contains a magnet link in its enclosure, whether or not to override it with the detected one.