### PR TITLE
feat: Image proxy endpoint and filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b79b82693f705137f8fb9b37871d99e4f9a7df12b917eed79c3d3954830a60b"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.12",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -182,7 +182,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
- "itoa",
+ "itoa 1.0.10",
  "matchit",
  "memchr",
  "mime",
@@ -450,6 +450,12 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
@@ -504,13 +510,30 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754b69d351cdc2d8ee09ae203db831e005560fc6030da058f86ad60c92a9cb0a"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa 0.4.8",
+ "matches",
+ "phf 0.8.0",
+ "proc-macro2",
+ "quote",
+ "smallvec",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "cssparser"
 version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b3df4f93e5fbbe73ec01ec8d3f68bba73107993a5b1e7519273c32db9b0d5be"
 dependencies = [
  "cssparser-macros",
  "dtoa-short",
- "itoa",
+ "itoa 1.0.10",
  "phf 0.11.2",
  "smallvec",
 ]
@@ -606,8 +629,10 @@ version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
+ "convert_case 0.4.0",
  "proc-macro2",
  "quote",
+ "rustc_version",
  "syn 1.0.109",
 ]
 
@@ -871,13 +896,24 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -891,6 +927,12 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "glob-match"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9985c9503b412198aa4197559e9a318524ebc4519c229bfa05a535828c950b9d"
 
 [[package]]
 name = "globset"
@@ -929,6 +971,15 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -989,7 +1040,7 @@ checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
 dependencies = [
  "bytes",
  "fnv",
- "itoa",
+ "itoa 1.0.10",
 ]
 
 [[package]]
@@ -1041,7 +1092,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 1.0.10",
  "pin-project-lite",
  "smallvec",
  "tokio",
@@ -1182,6 +1233,12 @@ dependencies = [
 
 [[package]]
 name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
@@ -1240,7 +1297,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -1266,6 +1323,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
+name = "lol_html"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4629ff9c2deeb7aad9b2d0f379fc41937a02f3b739f007732c46af40339dee5"
+dependencies = [
+ "bitflags 2.4.2",
+ "cfg-if",
+ "cssparser 0.27.2",
+ "encoding_rs",
+ "hashbrown 0.13.2",
+ "lazy_static",
+ "lazycell",
+ "memchr",
+ "mime",
+ "selectors 0.22.0",
+ "thiserror",
+]
+
+[[package]]
 name = "lru"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1288,7 +1364,7 @@ checksum = "7a2629bb1404f3d34c2e921f21fd34ba00b206124c81f65c50b43b6aaefeb016"
 dependencies = [
  "log",
  "phf 0.10.1",
- "phf_codegen",
+ "phf_codegen 0.10.0",
  "string_cache",
  "string_cache_codegen",
  "tendril",
@@ -1305,6 +1381,12 @@ dependencies = [
  "tendril",
  "xml5ever",
 ]
+
+[[package]]
+name = "matches"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "matchit"
@@ -1347,7 +1429,7 @@ checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
 
@@ -1362,6 +1444,12 @@ name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+
+[[package]]
+name = "nodrop"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "nom"
@@ -1489,6 +1577,17 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "phf"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
+dependencies = [
+ "phf_macros 0.8.0",
+ "phf_shared 0.8.0",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "phf"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
@@ -1502,8 +1601,18 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
 dependencies = [
- "phf_macros",
+ "phf_macros 0.11.2",
  "phf_shared 0.11.2",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815"
+dependencies = [
+ "phf_generator 0.8.0",
+ "phf_shared 0.8.0",
 ]
 
 [[package]]
@@ -1518,12 +1627,22 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526"
+dependencies = [
+ "phf_shared 0.8.0",
+ "rand 0.7.3",
+]
+
+[[package]]
+name = "phf_generator"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
  "phf_shared 0.10.0",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1533,7 +1652,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared 0.11.2",
- "rand",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6fde18ff429ffc8fe78e2bf7f8b7a5a5a6e2a8b58bc5a9ac69198bbda9189c"
+dependencies = [
+ "phf_generator 0.8.0",
+ "phf_shared 0.8.0",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1547,6 +1680,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.52",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -1662,6 +1804,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1691,13 +1839,37 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+ "rand_pcg",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1707,7 +1879,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -1716,7 +1897,25 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.12",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1830,7 +2029,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.12",
  "libc",
  "spin",
  "untrusted",
@@ -1866,7 +2065,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27b39e889cc951e3e5f6b74012f943e642fa0fac51a8552948751f19a9b62f8"
 dependencies = [
- "convert_case",
+ "convert_case 0.6.0",
  "fnv",
  "ident_case",
  "indexmap 2.2.5",
@@ -1918,16 +2117,18 @@ dependencies = [
  "either",
  "encoding_rs",
  "futures",
+ "glob-match",
  "html5ever",
  "htmlescape",
  "http",
  "itertools",
  "lazy_static",
+ "lol_html",
  "lru",
  "mime",
  "notify",
  "paste",
- "rand",
+ "rand 0.8.5",
  "readability",
  "regex",
  "reqwest",
@@ -2005,6 +2206,15 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -2117,13 +2327,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b80b33679ff7a0ea53d37f3b39de77ea0c75b12c5805ac43ec0c33b3051af1b"
 dependencies = [
  "ahash",
- "cssparser",
+ "cssparser 0.31.2",
  "ego-tree",
  "getopts",
  "html5ever",
  "once_cell",
- "selectors",
+ "selectors 0.25.0",
  "tendril",
+]
+
+[[package]]
+name = "selectors"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df320f1889ac4ba6bc0cdc9c9af7af4bd64bb927bccdf32d81140dc1f9be12fe"
+dependencies = [
+ "bitflags 1.3.2",
+ "cssparser 0.27.2",
+ "derive_more",
+ "fxhash",
+ "log",
+ "matches",
+ "phf 0.8.0",
+ "phf_codegen 0.8.0",
+ "precomputed-hash",
+ "servo_arc 0.1.1",
+ "smallvec",
+ "thin-slice",
 ]
 
 [[package]]
@@ -2133,17 +2363,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eb30575f3638fc8f6815f448d50cb1a2e255b0897985c8c59f4d37b72a07b06"
 dependencies = [
  "bitflags 2.4.2",
- "cssparser",
+ "cssparser 0.31.2",
  "derive_more",
  "fxhash",
  "log",
  "new_debug_unreachable",
  "phf 0.10.1",
- "phf_codegen",
+ "phf_codegen 0.10.0",
  "precomputed-hash",
- "servo_arc",
+ "servo_arc 0.3.0",
  "smallvec",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
@@ -2182,7 +2418,7 @@ version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
- "itoa",
+ "itoa 1.0.10",
  "ryu",
  "serde",
 ]
@@ -2193,7 +2429,7 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebd154a240de39fdebcf5775d2675c204d7c13cf39a4c697be6493c8e734337c"
 dependencies = [
- "itoa",
+ "itoa 1.0.10",
  "serde",
 ]
 
@@ -2204,7 +2440,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa",
+ "itoa 1.0.10",
  "ryu",
  "serde",
 ]
@@ -2216,10 +2452,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd075d994154d4a774f95b51fb96bdc2832b0ea48425c92546073816cda1f2f"
 dependencies = [
  "indexmap 2.2.5",
- "itoa",
+ "itoa 1.0.10",
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98238b800e0d1576d8b6e3de32827c2d74bee68bb97748dcf5071fb53965432"
+dependencies = [
+ "nodrop",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -2384,6 +2630,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "thin-slice"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaa81235c7058867fa8c0e7314f33dcce9c215f535d1913822a2b3f5e289f3c"
+
+[[package]]
 name = "thiserror"
 version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2420,7 +2672,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
 dependencies = [
  "deranged",
- "itoa",
+ "itoa 1.0.10",
  "num-conv",
  "powerfmt",
  "serde",
@@ -2764,6 +3016,12 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,6 +325,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
+name = "blake3"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cca6d3674597c30ddf2c587bf8d9d65c9a84d2326d941cc79c9842dfe0ef52"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +466,12 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
 name = "convert_case"
@@ -2110,6 +2135,7 @@ dependencies = [
  "axum-extra",
  "axum-macros",
  "base64 0.22.0",
+ "blake3",
  "chrono",
  "clap",
  "duration-str",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1811,10 +1811,12 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-socks",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
  "winreg",
@@ -2834,6 +2836,19 @@ name = "wasm-bindgen-shared"
 version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "web-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ duration-str = { version = "0.7.1", default-features = false, features = ["serde
 axum-macros = "0.4.1"
 axum = { version = "0.7.4", features = ["json"] }
 tower = "0.4.13"
-tower-http = { version = "0.5.2", features = ["compression-gzip"] }
+tower-http = { version = "0.5.2", features = ["compression-gzip", "cors"] }
 notify = { version = "6.1.1", default-features = false, features = ["macos_kqueue"] }
 
 # Feed formats support
@@ -70,7 +70,7 @@ serde_json = "1.0.114" # for data transfer with the JS runtime
 either = "1.10.0" # used for returning sum types from the JS runtime
 
 # Web client (blocking and async both used, blocking used in the JS runtime)
-reqwest = { version = "0.12.2", default-features = false, features = ["blocking", "trust-dns", "socks", "http2", "rustls-tls"] }
+reqwest = { version = "0.12.2", default-features = false, features = ["blocking", "trust-dns", "socks", "http2", "rustls-tls", "stream"] }
 encoding_rs = "0.8.33"
 lru = "0.12.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,9 @@ ego-tree = "0.6.2"
 readability = { version = "0.3.0", default-features = false }
 html5ever = "0.26.0"
 htmlescape = "0.3.1"
+lol_html = "1.2.1"
+urlencoding = "2.1.3"
+base64 = "0.22.0"
 
 # JS runtime crates
 rquickjs = { version = "0.5.1", features = ["loader", "parallel", "macro", "futures", "exports", "either"] }
@@ -76,13 +79,13 @@ lru = "0.12.3"
 
 # Used in sanitize filter to remove/replace text contents
 regex = "1.10.3"
+# Used in domain matching
+glob-match = "0.2.1"
 
 # Logging
 tracing = { version = "0.1.40"}
 tracing-subscriber = "0.3.18"
 axum-extra = { version = "0.9.2", features = ["cookie"] }
-base64 = "0.22.0"
-urlencoding = "2.1.3"
 
 [patch.crates-io]
 ego-tree = { git = "https://github.com/shouya/ego-tree.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ itertools = "0.12.1"
 paste = "1.0.14"
 tokio = { version = "1.36.0", features = ["macros", "net", "rt-multi-thread", "sync"] }
 lazy_static = "1.4.0"
+blake3 = "1.5.1"
 
 # Command line and config parsing
 clap = { version = "4.5.1", features = ["derive", "env"] }
@@ -39,6 +40,7 @@ duration-str = { version = "0.7.1", default-features = false, features = ["serde
 # webserver
 axum-macros = "0.4.1"
 axum = { version = "0.7.4", features = ["json"] }
+axum-extra = { version = "0.9.2", features = ["cookie"] }
 tower = "0.4.13"
 tower-http = { version = "0.5.2", features = ["compression-gzip", "cors"] }
 notify = { version = "6.1.1", default-features = false, features = ["macos_kqueue"] }
@@ -85,7 +87,6 @@ glob-match = "0.2.1"
 # Logging
 tracing = { version = "0.1.40"}
 tracing-subscriber = "0.3.18"
-axum-extra = { version = "0.9.2", features = ["cookie"] }
 
 [patch.crates-io]
 ego-tree = { git = "https://github.com/shouya/ego-tree.git" }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -244,4 +244,5 @@ define_filters!(
   ConvertTo => convert::ConvertToConfig, "Convert feed to another format";
   Limit => limit::LimitConfig, "Limit the number of posts";
   Magnet => magnet::MagnetConfig, "Find magnet links in posts";
+  ImageProxy => image_proxy::Config, "Find magnet links in posts";
 );

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -57,7 +57,7 @@ impl FilterContext {
 
     warn!(
       "Base URL not inferred, please refer to
-  https://github.com/shouya/rss-funnel/wiki/App-Base-Inference. Using demo instance as fallback."
+  https://github.com/shouya/rss-funnel/wiki/App-base. Using demo instance as fallback."
     );
 
     &crate::util::DEMO_INSTANCE

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 use url::Url;
 
 use crate::{
@@ -45,8 +46,21 @@ impl FilterContext {
     self.limit_filters
   }
 
-  pub fn base(&self) -> Option<&Url> {
+  pub fn base_opt(&self) -> Option<&Url> {
     self.base.as_ref()
+  }
+
+  pub fn base(&self) -> &Url {
+    if let Some(base) = &self.base {
+      return base;
+    }
+
+    warn!(
+      "Base URL not inferred, please refer to
+  https://github.com/shouya/rss-funnel/wiki/App-Base-Inference. Using demo instance as fallback."
+    );
+
+    &crate::util::DEMO_INSTANCE
   }
 
   pub fn set_limit_filters(&mut self, limit: usize) {

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -2,6 +2,7 @@ mod convert;
 mod full_text;
 mod highlight;
 mod html;
+mod image_proxy;
 mod js;
 mod limit;
 mod magnet;

--- a/src/filter/image_proxy.rs
+++ b/src/filter/image_proxy.rs
@@ -1,7 +1,16 @@
+use std::borrow::Cow;
+
 use serde::Deserialize;
+use tracing::warn;
+use url::Url;
+
+use super::{FeedFilter, FeedFilterConfig, FilterContext};
+use crate::{feed::Feed, util::ConfigError, Result};
+
+const IMAGE_PROXY_ROUTE: &str = "/_image";
 
 #[derive(Deserialize, Debug)]
-pub struct ImageProxyConfig {
+pub struct Config {
   /// Only rewrite images whose url matches one of the given
   /// domains. Globbing is supported: "*.example.com" matches
   /// "foo.example.com" but not "example.com".
@@ -10,29 +19,148 @@ pub struct ImageProxyConfig {
   /// selector.
   selector: Option<String>,
   #[serde(flatten)]
-  settings: Settings,
+  settings: ProxySettings,
+}
+
+impl Config {
+  fn selector(&self) -> String {
+    self.selector.clone().unwrap_or_else(|| "img".to_string())
+  }
 }
 
 #[derive(Deserialize, Debug)]
-enum Settings {
-  External(ExternalConfig),
+enum ProxySettings {
+  External(ExternalProxySettings),
   #[serde(untagged)]
-  // TODO: check if RSS_FUNNEL_IMAGE_PROXY is set, or raise a warning.
   Internal(crate::server::image_proxy::Config),
 }
 
+impl ProxySettings {
+  fn is_internal(&self) -> bool {
+    matches!(self, ProxySettings::Internal(_))
+  }
+
+  fn rewrite_image_url(&self, ctx: &FilterContext, image_url: Url) -> String {
+    match self {
+      ProxySettings::External(settings) => {
+        let urlencode = settings
+          .urlencode
+          .unwrap_or_else(|| settings.base.as_str().ends_with('='));
+        let image_url = if urlencode {
+          urlencoding::encode(image_url.as_str())
+        } else {
+          Cow::Borrowed(image_url.as_str())
+        };
+        let base = settings.base.as_str();
+
+        format!("{}{}", base, image_url)
+      }
+      ProxySettings::Internal(proxy) => {
+        let query = proxy.to_query(image_url.as_str());
+        let app_base = ctx.base();
+
+        match app_base.join(&format!("{}?{}", IMAGE_PROXY_ROUTE, query)) {
+          Ok(url) => url.to_string(),
+          Err(e) => {
+            warn!("Failed to rewrite image url: {}", e);
+            image_url.to_string()
+          }
+        }
+      }
+    }
+  }
+}
+
 #[derive(Deserialize, Debug)]
-struct ExternalConfig {
+struct ExternalProxySettings {
   /// The base URL to append the images to.
-  base: String,
+  base: Url,
   /// Whether to urlencode the images urls before appending them to
   /// the base. If base ends with a "=", this option defaults to true,
   /// otherwise it defaults to false.
   urlencode: Option<bool>,
 }
 
-struct InternalConfig {}
+#[async_trait::async_trait]
+impl FeedFilterConfig for Config {
+  type Filter = ImageProxy;
+
+  async fn build(self) -> Result<Self::Filter, ConfigError> {
+    if !crate::util::is_env_set("RSS_FUNNEL_IMAGE_PROXY")
+      && self.settings.is_internal()
+    {
+      return Err(ConfigError::FeatureNotSupported {
+        feature: "image_proxy",
+        reason:
+          "RSS_FUNNEL_IMAGE_PROXY is not set, internal image proxy is disabled.",
+      });
+    }
+
+    Ok(ImageProxy { config: self })
+  }
+}
 
 pub struct ImageProxy {
-  config: ImageProxyConfig,
+  config: Config,
+}
+
+#[async_trait::async_trait]
+impl FeedFilter for ImageProxy {
+  async fn run(&self, ctx: &mut FilterContext, mut feed: Feed) -> Result<Feed> {
+    let mut posts = feed.take_posts();
+
+    for post in posts.iter_mut() {
+      for body in post.bodies_mut() {
+        if let Some(new_body) = rewrite_html(ctx, &self.config, body) {
+          *body = new_body;
+        }
+      }
+    }
+
+    feed.set_posts(posts);
+    Ok(feed)
+  }
+}
+
+fn rewrite_html(
+  ctx: &FilterContext,
+  config: &Config,
+  html: &str,
+) -> Option<String> {
+  use glob_match::glob_match;
+  use lol_html::{element, RewriteStrSettings};
+
+  let selector = config.selector();
+  let matches_domain = |url: &Url| match (&config.domains, url.domain()) {
+    (None, _) => true,
+    (_, None) => false,
+    (Some(ref domains), Some(domain)) => {
+      domains.iter().any(|pat| glob_match(pat, domain))
+    }
+  };
+
+  let rewrite = element!(selector, |el| {
+    let new_src = el
+      .get_attribute("src")
+      .iter()
+      .filter_map(|src| Url::parse(src).ok())
+      .filter(matches_domain)
+      .map(|url| config.settings.rewrite_image_url(ctx, url))
+      .next();
+
+    if let Some(new_src) = new_src {
+      el.set_attribute("src", &new_src)?;
+    }
+
+    Ok(())
+  });
+
+  lol_html::rewrite_str(
+    html,
+    RewriteStrSettings {
+      element_content_handlers: vec![rewrite],
+      ..RewriteStrSettings::default()
+    },
+  )
+  .ok()
 }

--- a/src/filter/image_proxy.rs
+++ b/src/filter/image_proxy.rs
@@ -145,16 +145,6 @@ impl FeedFilterConfig for Config {
   type Filter = ImageProxy;
 
   async fn build(self) -> Result<Self::Filter, ConfigError> {
-    if !crate::util::is_env_set("RSS_FUNNEL_IMAGE_PROXY")
-      && self.settings.is_internal()
-    {
-      return Err(ConfigError::FeatureNotSupported {
-        feature: "image_proxy",
-        reason:
-          "RSS_FUNNEL_IMAGE_PROXY is not set, internal image proxy is disabled.",
-      });
-    }
-
     Ok(ImageProxy { config: self })
   }
 }

--- a/src/filter/image_proxy.rs
+++ b/src/filter/image_proxy.rs
@@ -40,10 +40,6 @@ enum ProxySettings {
 }
 
 impl ProxySettings {
-  fn is_internal(&self) -> bool {
-    matches!(self, ProxySettings::Internal(_))
-  }
-
   fn rewrite_image_url(&self, ctx: &FilterContext, image_url: Url) -> String {
     match self {
       ProxySettings::External(settings) => {

--- a/src/filter/image_proxy.rs
+++ b/src/filter/image_proxy.rs
@@ -1,0 +1,38 @@
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug)]
+pub struct ImageProxyConfig {
+  /// Only rewrite images whose url matches one of the given
+  /// domains. Globbing is supported: "*.example.com" matches
+  /// "foo.example.com" but not "example.com".
+  domains: Option<Vec<String>>,
+  /// Only rewrite urls of <img> tags matching the following CSS
+  /// selector.
+  selector: Option<String>,
+  #[serde(flatten)]
+  settings: Settings,
+}
+
+#[derive(Deserialize, Debug)]
+enum Settings {
+  External(ExternalConfig),
+  #[serde(untagged)]
+  // TODO: check if RSS_FUNNEL_IMAGE_PROXY is set, or raise a warning.
+  Internal(crate::server::image_proxy::Config),
+}
+
+#[derive(Deserialize, Debug)]
+struct ExternalConfig {
+  /// The base URL to append the images to.
+  base: String,
+  /// Whether to urlencode the images urls before appending them to
+  /// the base. If base ends with a "=", this option defaults to true,
+  /// otherwise it defaults to false.
+  urlencode: Option<bool>,
+}
+
+struct InternalConfig {}
+
+pub struct ImageProxy {
+  config: ImageProxyConfig,
+}

--- a/src/filter/merge.rs
+++ b/src/filter/merge.rs
@@ -128,7 +128,7 @@ impl Merge {
 #[async_trait::async_trait]
 impl FeedFilter for Merge {
   async fn run(&self, ctx: &mut FilterContext, mut feed: Feed) -> Result<Feed> {
-    let base = ctx.base();
+    let base = ctx.base_opt();
     for new_feed in self.fetch_sources(base).await? {
       let ctx = ctx.subcontext();
       let filtered_new_feed = self.filters.run(ctx, new_feed).await?;

--- a/src/server.rs
+++ b/src/server.rs
@@ -129,15 +129,18 @@ impl ServerConfig {
       app = app.route("/", get(|| async { "rss-funnel is up and running!" }));
     }
 
-    app = app
-      .route("/health", get(|| async { "ok" }))
-      .nest("/_image", image_proxy::router())
+    let feed_service_router = Router::new()
       .route("/:endpoint", get(FeedService::handler))
-      .layer(Extension(feed_service))
       .fallback(get(|| async {
         (StatusCode::NOT_FOUND, "Endpoint not found")
       }))
       .layer(CompressionLayer::new().gzip(true));
+
+    app = app
+      .route("/health", get(|| async { "ok" }))
+      .merge(image_proxy::router())
+      .merge(feed_service_router)
+      .layer(Extension(feed_service));
 
     info!("starting server");
     let server = axum::serve(listener, app);

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,7 +1,7 @@
 mod auth;
 mod endpoint;
 mod feed_service;
-mod image_proxy;
+pub mod image_proxy;
 #[cfg(feature = "inspector-ui")]
 mod inspector;
 mod watcher;

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,6 +1,7 @@
 mod auth;
 mod endpoint;
 mod feed_service;
+mod image_proxy;
 #[cfg(feature = "inspector-ui")]
 mod inspector;
 mod watcher;
@@ -130,6 +131,7 @@ impl ServerConfig {
 
     app = app
       .route("/health", get(|| async { "ok" }))
+      .get("/_image", get(image_proxy::handler))
       .route("/:endpoint", get(FeedService::handler))
       .layer(Extension(feed_service))
       .fallback(get(|| async {

--- a/src/server.rs
+++ b/src/server.rs
@@ -131,7 +131,7 @@ impl ServerConfig {
 
     app = app
       .route("/health", get(|| async { "ok" }))
-      .get("/_image", get(image_proxy::handler))
+      .nest("/_image", image_proxy::router())
       .route("/:endpoint", get(FeedService::handler))
       .layer(Extension(feed_service))
       .fallback(get(|| async {

--- a/src/server/image_proxy.rs
+++ b/src/server/image_proxy.rs
@@ -1,0 +1,182 @@
+use axum::{body::Body, extract::Query, response::IntoResponse};
+use serde::Deserialize;
+use thiserror::Error;
+
+use crate::util;
+
+#[derive(Default, Debug, Deserialize, PartialEq, Eq)]
+struct ProxyQuery {
+  #[serde(rename = "url")]
+  image_url: String,
+  #[serde(default, flatten)]
+  config: Config,
+}
+
+#[derive(Error, Debug)]
+enum Error {
+  #[error("HTTP error: {0}")]
+  Reqwest(#[from] reqwest::Error),
+}
+
+impl IntoResponse for Error {
+  fn into_response(self) -> http::Response<Body> {
+    http::Response::builder()
+      .status(http::StatusCode::INTERNAL_SERVER_ERROR)
+      .body(Body::from(self.to_string()))
+      .unwrap()
+  }
+}
+
+type Result<T> = std::result::Result<T, Error>;
+
+pub async fn handler(
+  Query(ProxyQuery { image_url, config }): Query<ProxyQuery>,
+  client_req: http::Request<Body>,
+) -> Result<impl IntoResponse> {
+  let mut client = reqwest::Client::builder();
+  if let Some(proxy) = q.config.proxy {
+    client = client.proxy(reqwest::Proxy::all(proxy).unwrap());
+  }
+  let client = client.build()?;
+
+  let mut proxy_req = client.get(&image_url);
+
+  let user_agent = config.user_agent.unwrap_or_default();
+  let user_agent = user_agent.calc_value(&client)?;
+  if let Some(user_agent) = user_agent {
+    proxy_req.header("user-agent", user_agent);
+  }
+  let referer = config.referer.unwrap_or_default();
+  let referer = referer.calc_value(&image_url, &client_req)?;
+  if let Some(referer) = referer {
+    proxy_req.header("referer", referer);
+  }
+
+  let res = proxy_req.send().await?;
+  let mut res = http::Response::builder()
+    .status(res.status())
+    .header("content-type", res.headers().get("content-type").unwrap())
+    .body(res.bytes().await?)
+    .unwrap();
+}
+
+#[derive(Default, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum Referer {
+  #[default]
+  None,
+  ImageUrl,
+  ImageUrlDomain,
+  Transparent,
+  TransparentDomain,
+  #[serde(untagged)]
+  Fixed(String),
+}
+
+impl Referer {
+  fn calc_value<B>(
+    &self,
+    url: &str,
+    req: &http::Request<B>,
+  ) -> Result<Option<String>> {
+    match self {
+      Self::None => Ok(None),
+      Self::ImageUrl => Ok(Some(url.to_string())),
+      Self::ImageUrlDomain => {
+        let url = url::Url::parse(url)?;
+        let domain = url.domain()?;
+        Ok(Some(format!("{}://{}", url.scheme(), domain)))
+      }
+      Self::Transparent => {
+        let Some(referer) = req.headers().get("referer") else {
+          return Ok(None);
+        };
+        Ok(Some(referer.to_str()?.to_string()))
+      }
+      Self::TransparentDomain => {
+        let referer = req.headers().get("referer")?.to_str()?;
+        let url = url::Url::parse(referer)?;
+        let domain = url.domain()?;
+        Ok(Some(format!("{}://{}", url.scheme(), domain)))
+      }
+      Self::Fixed(s) => Ok(Some(s.clone())),
+    }
+  }
+}
+
+#[derive(Default, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum UserAgent {
+  None,
+  #[default]
+  Transparent,
+  RssFunnel,
+  #[serde(untagged)]
+  Fixed(String),
+}
+
+impl UserAgent {
+  fn calc_value<B>(&self, req: &http::Request<B>) -> Result<Option<String>> {
+    match self {
+      Self::None => Ok(None),
+      Self::Transparent => {
+        let Some(user_agent) = req.headers().get("user-agent") else {
+          return Ok(None);
+        };
+        Ok(Some(user_agent.to_str()?.to_string()))
+      }
+      Self::RssFunnel => Ok(Some(util::USER_AGENT.to_string())),
+      Self::Fixed(s) => Ok(Some(s.clone())),
+    }
+  }
+}
+
+#[derive(Default, Debug, Deserialize, PartialEq, Eq)]
+struct Config {
+  referer: Option<Referer>,
+  user_agent: Option<String>,
+  proxy: Option<String>,
+}
+
+#[cfg(test)]
+mod test {
+  use super::*;
+  use serde_json::json;
+
+  #[test]
+  fn test_parse_config() {
+    let parsed: Config = serde_json::from_value(json!({})).unwrap();
+    let expected = Config::default();
+    assert_eq!(parsed, expected);
+
+    let parsed: Config = serde_json::from_value(json!({
+      "referer": "none"
+    }))
+    .unwrap();
+    let expected = Config {
+      referer: Some(Referer::None),
+      ..Default::default()
+    };
+    assert_eq!(parsed, expected);
+
+    let parsed: Config = serde_json::from_value(json!({
+      "referer": "transparent"
+    }))
+    .unwrap();
+    let expected = Config {
+      referer: Some(Referer::Transparent),
+      ..Default::default()
+    };
+    assert_eq!(parsed, expected);
+
+    let parsed: Config = serde_json::from_value(json!({
+      "referer": "http://example.com"
+    }))
+    .unwrap();
+    let expected = Config {
+      referer: Some(Referer::Fixed("http://example.com".to_string())),
+      ..Default::default()
+    };
+    assert_eq!(parsed, expected);
+  }
+}

--- a/src/server/image_proxy.rs
+++ b/src/server/image_proxy.rs
@@ -388,7 +388,7 @@ impl Config {
         Referer::ImageUrlDomain => "image_url_domain",
         Referer::Transparent => "transparent",
         Referer::TransparentDomain => "transparent_domain",
-        Referer::Fixed(s) => s,
+        Referer::Fixed(s) => &urlencoding::encode(s),
       };
       params.push(format!("referer={referer}"));
     }
@@ -398,15 +398,17 @@ impl Config {
         UserAgent::None => "none",
         UserAgent::Transparent => "transparent",
         UserAgent::RssFunnel => "rss_funnel",
-        UserAgent::Fixed(s) => s,
+        UserAgent::Fixed(s) => &urlencoding::encode(s),
       };
       params.push(format!("user_agent={user_agent}"));
     }
 
     if let Some(proxy) = &self.proxy {
+      let proxy = &urlencoding::encode(proxy);
       params.push(format!("proxy={proxy}"));
     }
 
+    let image_url = &urlencoding::encode(image_url);
     params.push(format!("url={image_url}"));
     params.join("&")
   }

--- a/src/server/image_proxy.rs
+++ b/src/server/image_proxy.rs
@@ -14,6 +14,10 @@ use url::Url;
 use crate::util;
 
 pub fn router() -> Router {
+  if !util::is_env_set("RSS_FUNNEL_IMAGE_PROXY") {
+    return Router::new();
+  }
+
   use tower_http::cors::AllowOrigin;
   let cors = CorsLayer::new()
     .allow_origin(AllowOrigin::any())

--- a/src/server/image_proxy.rs
+++ b/src/server/image_proxy.rs
@@ -19,10 +19,6 @@ lazy_static::lazy_static! {
 }
 
 pub fn router() -> Router {
-  if !util::is_env_set("RSS_FUNNEL_IMAGE_PROXY") {
-    return Router::new();
-  }
-
   info!("loaded image proxy: /_image");
 
   use tower_http::cors::AllowOrigin;

--- a/src/server/image_proxy.rs
+++ b/src/server/image_proxy.rs
@@ -12,8 +12,6 @@ use tower_http::cors::CorsLayer;
 use tracing::{info, warn};
 use url::Url;
 
-use crate::util;
-
 lazy_static::lazy_static! {
   static ref SIGN_KEY: Box<[u8]> = init_sign_key();
 }
@@ -282,7 +280,6 @@ enum UserAgent {
   None,
   #[default]
   Transparent,
-  RssFunnel,
   #[serde(untagged)]
   Fixed(String),
 }
@@ -300,7 +297,6 @@ impl UserAgent {
         })?;
         Ok(Some(user_agent.to_string()))
       }
-      Self::RssFunnel => Ok(Some(util::USER_AGENT.to_string())),
       Self::Fixed(s) => Ok(Some(s.clone())),
     }
   }
@@ -391,7 +387,6 @@ impl Config {
       let user_agent = match user_agent {
         UserAgent::None => "none",
         UserAgent::Transparent => "transparent",
-        UserAgent::RssFunnel => "rss_funnel",
         UserAgent::Fixed(s) => &urlencoding::encode(s),
       };
       params.push(format!("user_agent={user_agent}"));

--- a/src/server/image_proxy.rs
+++ b/src/server/image_proxy.rs
@@ -252,31 +252,31 @@ pub struct Config {
 }
 
 impl Config {
-  fn to_query(self, image_url: &str) -> String {
+  pub fn to_query(&self, image_url: &str) -> String {
     let mut params = vec![];
-    if let Some(referer) = self.referer {
-      let referer = match &referer {
+    if let Some(referer) = &self.referer {
+      let referer = match referer {
         Referer::None => "none",
         Referer::ImageUrl => "image_url",
         Referer::ImageUrlDomain => "image_url_domain",
         Referer::Transparent => "transparent",
         Referer::TransparentDomain => "transparent_domain",
-        Referer::Fixed(s) => &s,
+        Referer::Fixed(s) => s,
       };
       params.push(format!("referer={referer}"));
     }
 
-    if let Some(user_agent) = self.user_agent {
-      let user_agent = match &user_agent {
+    if let Some(user_agent) = &self.user_agent {
+      let user_agent = match user_agent {
         UserAgent::None => "none",
         UserAgent::Transparent => "transparent",
         UserAgent::RssFunnel => "rss_funnel",
-        UserAgent::Fixed(s) => &s,
+        UserAgent::Fixed(s) => s,
       };
       params.push(format!("user_agent={user_agent}"));
     }
 
-    if let Some(proxy) = self.proxy {
+    if let Some(proxy) = &self.proxy {
       params.push(format!("proxy={proxy}"));
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -10,6 +10,7 @@ lazy_static::lazy_static! {
     Url::parse("https://rss-funnel-demo.fly.dev/").unwrap();
 }
 
+#[allow(unused)]
 pub fn is_env_set(name: &str) -> bool {
   let Ok(mut val) = std::env::var(name) else {
     return false;
@@ -62,12 +63,6 @@ pub enum ConfigError {
 
   #[error("Duplicate endpoint: {0}")]
   DuplicateEndpoint(String),
-
-  #[error("Feature {feature} not supported: {reason}")]
-  FeatureNotSupported {
-    feature: &'static str,
-    reason: &'static str,
-  },
 
   #[error("{0}")]
   Message(String),

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,6 +5,11 @@ use url::Url;
 pub const USER_AGENT: &str =
   concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
 
+lazy_static::lazy_static! {
+  pub static ref DEMO_INSTANCE: Url =
+    Url::parse("https://rss-funnel-demo.fly.dev/").unwrap();
+}
+
 pub fn is_env_set(name: &str) -> bool {
   let Ok(mut val) = std::env::var(name) else {
     return false;
@@ -57,6 +62,12 @@ pub enum ConfigError {
 
   #[error("Duplicate endpoint: {0}")]
   DuplicateEndpoint(String),
+
+  #[error("Feature {feature} not supported: {reason}")]
+  FeatureNotSupported {
+    feature: &'static str,
+    reason: &'static str,
+  },
 
   #[error("{0}")]
   Message(String),

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,6 +5,15 @@ use url::Url;
 pub const USER_AGENT: &str =
   concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
 
+pub fn is_env_set(name: &str) -> bool {
+  let Ok(mut val) = std::env::var(name) else {
+    return false;
+  };
+
+  val.make_ascii_lowercase();
+  matches!(val.as_str(), "1" | "t" | "true" | "y" | "yes")
+}
+
 // pub type DateTime = time::OffsetDateTime;
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 


### PR DESCRIPTION
This PR implements image proxy support. It contains two parts:

- an image proxy server running behind `/_image` endpoint
- a filter to rewrite image URLs to the image proxy server

See [Image proxy](https://github.com/shouya/rss-funnel/wiki/Image-proxy) page for detailed usage.

