### PR TITLE
feat: Health check command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM scratch
+COPY %RELEASE_BINARY% /rss-funnel
+ENTRYPOINT ["/rss-funnel"]
+EXPOSE 8080
+HEALTHCHECK CMD ["/rss-funnel", "health-check"]
+CMD ["server"]

--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,11 @@ $(IMAGE_NAME)\:latest-% $(IMAGE_NAME)\:nightly-%: $(IMAGE_NAME)\:$(VERSION)-%
 	podman tag $< $@
 
 $(IMAGE_NAME)\:$(VERSION)-%: target/%/release/$(APP_NAME)
-	echo "FROM scratch\nCOPY $< /$(APP_NAME)\nENTRYPOINT [\"/$(APP_NAME)\"]\nCMD [\"server\"]\n" | \
-		podman build -f - . --platform $(PLATFORM_$*) -t $@
+	cat Dockerfile | \
+		sed -e "s|%RELEASE_BINARY%|$<|g" | \
+		podman build -f - . \
+			--format docker \
+			--platform $(PLATFORM_$*) -t $@
 
 # building multiarch manifest requires the image to be pushed to the
 # registry first.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -36,7 +36,7 @@ struct HealthCheckConfig {
     long,
     short,
     default_value = "127.0.0.1:4080",
-    env = "RSS_FUNNEL_BIND"
+    env = "RSS_FUNNEL_HEALTH_CHECK_SERVER"
   )]
   server: String,
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -137,7 +137,9 @@ impl ServerConfig {
       .layer(CompressionLayer::new().gzip(true));
 
     app = app
+      // deprecated, will be removed on 0.2
       .route("/health", get(|| async { "ok" }))
+      .route("/_health", get(|| async { "ok" }))
       .merge(image_proxy::router())
       .merge(feed_service_router)
       .layer(Extension(feed_service));


### PR DESCRIPTION
This PR adds a `health-check` command to the CLI. You can call `rss-funnel health-check` to check if the server is running and healthy. The Docker image now also includes the `HEALTHCHECK CMD` directive.

Internally it does a simple GET request to the `/_health` endpoint.

Options:

- `-s`/`--server`/`RSS_FUNNEL_HEALTH_CHECK_SERVER` - The server to check. Default: `http://127.0.0.1:4080`.

Closes #128.