### PR TITLE
fix: improve source error message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2702,9 +2702,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa 1.0.10",
@@ -2723,9 +2723,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",

--- a/src/server/endpoint.rs
+++ b/src/server/endpoint.rs
@@ -207,9 +207,10 @@ impl EndpointService {
   async fn handle(self, mut req: Request) -> Result<Response, Response> {
     // infallible
     let param: EndpointParam = req.extract_parts().await.unwrap();
-    let feed = self.run(param).await.map_err(|e| {
-      (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
-    })?;
+    let feed = self
+      .run(param)
+      .await
+      .map_err(|e| e.as_response().into_response())?;
     let resp = feed.into_response();
     Ok(resp)
   }
@@ -242,7 +243,8 @@ impl EndpointService {
     let source = self.find_source(&param.source)?;
     let feed = source
       .fetch_feed(Some(&self.client), param.base.as_ref())
-      .await?;
+      .await
+      .map_err(|e| Error::FetchSource(Box::new(e)))?;
     let mut context = FilterContext::new();
     if let Some(limit_filters) = param.limit_filters {
       context.set_limit_filters(limit_filters);

--- a/src/server/endpoint.rs
+++ b/src/server/endpoint.rs
@@ -209,7 +209,7 @@ impl EndpointService {
     let feed = self
       .run(param)
       .await
-      .map_err(|e| e.as_response().into_response())?;
+      .map_err(|e| e.into_http().into_response())?;
     let resp = feed.into_response();
     Ok(resp)
   }

--- a/src/server/endpoint.rs
+++ b/src/server/endpoint.rs
@@ -11,7 +11,6 @@ use axum::response::IntoResponse;
 use axum::RequestExt;
 use http::header::HOST;
 use http::request::Parts;
-use http::StatusCode;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;

--- a/src/util.rs
+++ b/src/util.rs
@@ -127,10 +127,10 @@ pub enum Error {
 }
 
 impl Error {
-  pub fn as_response(self) -> (StatusCode, String) {
+  pub fn into_http(self) -> (StatusCode, String) {
     match self {
       Error::FetchSource(e) => {
-        let (status, body) = e.as_response();
+        let (status, body) = e.into_http();
         (status, format!("Error fetching source: {body}"))
       }
       Error::HttpStatus(status, url) => {

--- a/src/util.rs
+++ b/src/util.rs
@@ -129,12 +129,15 @@ pub enum Error {
 impl Error {
   pub fn as_response(self) -> (StatusCode, String) {
     match self {
+      Error::FetchSource(e) => {
+        let (status, body) = e.as_response();
+        (status, format!("Fetch source error: {body}"))
+      }
       Error::HttpStatus(status, url) => {
-        let body = format!("{}: {}", status, url);
+        let body = format!("Error fetching {url}");
         (status, body)
       }
-      Error::Message(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
-      Error::FeedParse(msg) => (StatusCode::BAD_REQUEST, msg.to_string()),
+      _ => (StatusCode::INTERNAL_SERVER_ERROR, format!("{self}")),
     }
   }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -131,11 +131,11 @@ impl Error {
     match self {
       Error::FetchSource(e) => {
         let (status, body) = e.as_response();
-        (status, format!("Fetch source error: {body}"))
+        (status, format!("Error fetching source: {body}"))
       }
       Error::HttpStatus(status, url) => {
-        let body = format!("Error fetching {url}");
-        (status, body)
+        let body = format!("Error requesting {url}: {status}");
+        (StatusCode::BAD_GATEWAY, body)
       }
       _ => (StatusCode::INTERNAL_SERVER_ERROR, format!("{self}")),
     }


### PR DESCRIPTION
Previously, if an endpoint failed to fetch the source, the endpoint would respond with a status 500 and an error message too specific. For example, it could be a "500: bad url" which is not very clear to the user that it's the source url that's broken or an url elsewhere.

This commit improves on the error message by providing a more user-friendly message:

- http request errors from anywhere in the pipeline will show as a 502 error with the failed status code and the requesting url is returned in the error message
- source errors will indicate it's a source error