### PR TITLE
feat: Placeholders in source

### DIFF
--- a/src/server/endpoint.rs
+++ b/src/server/endpoint.rs
@@ -115,6 +115,12 @@ pub struct EndpointParam {
   query: Option<String>,
 }
 
+impl EndpointParam {
+  pub const fn all_fields() -> &'static [&'static str] {
+    &["source", "limit_filters", "limit_posts"]
+  }
+}
+
 #[async_trait]
 impl<S> FromRequestParts<S> for EndpointParam
 where

--- a/src/server/endpoint.rs
+++ b/src/server/endpoint.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::convert::Infallible;
 use std::future::Future;
 use std::pin::Pin;
@@ -113,11 +114,26 @@ pub struct EndpointParam {
   /// The full query string
   #[serde(skip)]
   query: Option<String>,
+  /// Extra query parameters
+  #[serde(flatten)]
+  extra_queries: HashMap<String, String>,
 }
 
 impl EndpointParam {
   pub const fn all_fields() -> &'static [&'static str] {
     &["source", "limit_filters", "limit_posts"]
+  }
+
+  pub(crate) fn base(&self) -> Option<&Url> {
+    self.base.as_ref()
+  }
+
+  pub(crate) fn limit_filters(&self) -> Option<usize> {
+    self.limit_filters
+  }
+
+  pub(crate) fn extra_queries(&self) -> &HashMap<String, String> {
+    &self.extra_queries
   }
 }
 
@@ -158,6 +174,7 @@ impl EndpointParam {
       limit_posts,
       base,
       query: None,
+      extra_queries: HashMap::new(),
     }
   }
 
@@ -246,11 +263,11 @@ impl EndpointService {
 
   pub async fn run(self, param: EndpointParam) -> Result<Feed> {
     let source = self.find_source(&param.source)?;
+    let mut context = FilterContext::from_param(&param);
     let feed = source
-      .fetch_feed(Some(&self.client), param.base.as_ref())
+      .fetch_feed(&context, Some(&self.client))
       .await
       .map_err(|e| Error::FetchSource(Box::new(e)))?;
-    let mut context = FilterContext::new();
     if let Some(limit_filters) = param.limit_filters {
       context.set_limit_filters(limit_filters);
     }

--- a/src/source.rs
+++ b/src/source.rs
@@ -249,7 +249,8 @@ description: "A test feed"
 
     let config: SourceConfig = serde_yaml::from_str(YAML_CONFIG).unwrap();
     let source = Source::try_from(config).unwrap();
-    let feed: Feed = source.fetch_feed(None, None).await.unwrap();
+    let ctx = FilterContext::new();
+    let feed: Feed = source.fetch_feed(&ctx, None).await.unwrap();
     assert_eq!(feed.title(), "Test Feed");
     assert_eq!(feed.format(), FeedFormat::Rss);
   }
@@ -265,7 +266,8 @@ description: "A test feed"
 
     let config: SourceConfig = serde_yaml::from_str(YAML_CONFIG).unwrap();
     let source = Source::try_from(config).unwrap();
-    let feed: Feed = source.fetch_feed(None, None).await.unwrap();
+    let ctx = FilterContext::new();
+    let feed: Feed = source.fetch_feed(&ctx, None).await.unwrap();
     assert_eq!(feed.title(), "Test Feed");
     assert_eq!(feed.format(), FeedFormat::Atom);
   }

--- a/src/source.rs
+++ b/src/source.rs
@@ -53,7 +53,7 @@ pub struct Templated {
 struct Placeholder {
   /// The default value of the placeholder. If not set, the placeholder
   /// is required.
-  default_value: Option<String>,
+  default: Option<String>,
 
   /// The regular expression that the placeholder must match. If not
   /// set, the placeholder can be any value. The validation is checked
@@ -71,7 +71,7 @@ impl Templated {
     for (name, placeholder) in &self.placeholders {
       let value = params
         .get(name)
-        .or(placeholder.default_value.as_ref())
+        .or(placeholder.default.as_ref())
         .ok_or(Error::MissingSourceTemplatePlaceholder(name.clone()))?
         .clone();
 

--- a/src/source.rs
+++ b/src/source.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 use regex::Regex;
 use schemars::JsonSchema;
@@ -8,6 +8,7 @@ use url::Url;
 use crate::{
   client::Client,
   feed::{Feed, FeedFormat},
+  filter::FilterContext,
   server::EndpointParam,
   util::{ConfigError, Error, Result},
 };
@@ -39,11 +40,11 @@ pub enum SourceConfig {
 )]
 pub struct Templated {
   /// The url of the source
-  pub template: String,
+  template: String,
   /// The placeholders. The key is the placeholder name and the value
   /// defines the value of the placeholder.
   // using BTreeMap instead of HashMap only because it implements Hash
-  pub placeholders: BTreeMap<String, Placeholder>,
+  placeholders: BTreeMap<String, Placeholder>,
 }
 
 #[derive(
@@ -58,6 +59,41 @@ struct Placeholder {
   /// set, the placeholder can be any value. The validation is checked
   /// against the url-decoded value.
   validation: Option<String>,
+}
+
+impl Templated {
+  fn to_regular_source(
+    &self,
+    params: &HashMap<String, String>,
+  ) -> Result<Source> {
+    let mut url = self.template.clone();
+
+    for (name, placeholder) in &self.placeholders {
+      let value = params
+        .get(name)
+        .or(placeholder.default_value.as_ref())
+        .ok_or(Error::MissingSourceTemplatePlaceholder(name.clone()))?
+        .clone();
+
+      if let Some(validation) = &placeholder.validation {
+        // already validated, so unwrap is safe
+        let re = Regex::new(validation).unwrap();
+        if !re.is_match(&value) {
+          return Err(Error::SourceTemplateValidation {
+            placeholder: name.clone(),
+            validation: validation.clone(),
+            input: value,
+          });
+        }
+      }
+
+      url = url.replace(&format!("%{name}%"), &value);
+    }
+
+    SourceConfig::Simple(url)
+      .try_into()
+      .map_err(|e: ConfigError| e.into())
+  }
 }
 
 #[derive(
@@ -112,14 +148,14 @@ impl TryFrom<SourceConfig> for Source {
 }
 
 fn validate_placeholders(config: &Templated) -> Result<(), ConfigError> {
-  // Validation 0: placeholders must not be empty
+  // Validation: placeholders must not be empty
   if config.placeholders.is_empty() {
     return Err(ConfigError::BadSourceTemplate(
       "placeholders must not be empty for templated source".into(),
     ));
   }
 
-  // Validation 1: all placeholders must present in template
+  // Validation: all placeholders must present in template
   for name in config.placeholders.keys() {
     if !config.template.contains(&format!("%{name}%")) {
       return Err(ConfigError::BadSourceTemplate(format!(
@@ -128,7 +164,7 @@ fn validate_placeholders(config: &Templated) -> Result<(), ConfigError> {
     }
   }
 
-  // Validation 2: all placeholder patterns in template must be
+  // Validation: all placeholder patterns in template must be
   // defined in placeholders
   lazy_static::lazy_static! {
     static ref RE: Regex = Regex::new(r"%(?<name>\w+)%").unwrap();
@@ -142,7 +178,7 @@ fn validate_placeholders(config: &Templated) -> Result<(), ConfigError> {
     }
   }
 
-  // Validation 3: all placeholder names must not be reserved words.
+  // Validation: all placeholder names must not be reserved words.
   const RESERVED_PARAMS: &[&str] = EndpointParam::all_fields();
   for name in config.placeholders.keys() {
     if RESERVED_PARAMS.contains(&name.as_str()) {
@@ -152,32 +188,47 @@ fn validate_placeholders(config: &Templated) -> Result<(), ConfigError> {
     }
   }
 
+  // Validation: all parameter's validation regex must be valid regex
+  for (name, placeholder) in &config.placeholders {
+    if let Some(validation) = &placeholder.validation {
+      Regex::new(validation).map_err(|e| {
+        ConfigError::BadSourceTemplate(format!(
+          "invalid regex for placeholder %{name}%: {e}",
+        ))
+      })?;
+    }
+  }
+
   Ok(())
 }
 
 impl Source {
   pub async fn fetch_feed(
     &self,
+    context: &FilterContext,
     client: Option<&Client>,
-    base: Option<&Url>,
   ) -> Result<Feed> {
     if let Source::FromScratch(config) = self {
       let feed = Feed::from(config);
       return Ok(feed);
     }
 
-    let client =
-      client.ok_or_else(|| Error::Message("client not set".into()))?;
+    if let Source::Templated(config) = self {
+      let source = config.to_regular_source(context.extra_queries())?;
+      return Box::pin(source.fetch_feed(context, client)).await;
+    }
+
     let source_url = match self {
       Source::AbsoluteUrl(url) => url.clone(),
       Source::RelativeUrl(path) => {
-        let base =
-          base.ok_or_else(|| Error::Message("base_url not set".into()))?;
+        let base = context.base_expected()?;
         base.join(path)?
       }
-      Source::FromScratch(_) => unreachable!(),
+      Source::Templated(_) | Source::FromScratch(_) => unreachable!(),
     };
 
+    let client =
+      client.ok_or_else(|| Error::Message("client not set".into()))?;
     client.fetch_feed(&source_url).await
   }
 }

--- a/src/source.rs
+++ b/src/source.rs
@@ -87,7 +87,8 @@ impl Templated {
         }
       }
 
-      url = url.replace(&format!("%{name}%"), &value);
+      let encoded_value = urlencoding::encode(&value);
+      url = url.replace(&format!("%{name}%"), &encoded_value);
     }
 
     SourceConfig::Simple(url)

--- a/src/util.rs
+++ b/src/util.rs
@@ -65,6 +65,9 @@ pub enum ConfigError {
   #[error("Duplicate endpoint: {0}")]
   DuplicateEndpoint(String),
 
+  #[error("Bad source template: {0}")]
+  BadSourceTemplate(String),
+
   #[error("{0}")]
   Message(String),
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -125,6 +125,19 @@ pub enum Error {
   #[error("Failed fetching source: {0}")]
   FetchSource(Box<Error>),
 
+  #[error("Source parameter {placeholder} failed to match validation: {validation} (input: {input})")]
+  SourceTemplateValidation {
+    placeholder: String,
+    validation: String,
+    input: String,
+  },
+
+  #[error("Source template placeholder unspecified: {0}")]
+  MissingSourceTemplatePlaceholder(String),
+
+  #[error("Based URL not inferred, please refer to https://github.com/shouya/rss-funnel/wiki/App-base")]
+  BaseUrlNotInferred,
+
   #[error("{0}")]
   Message(String),
 }
@@ -139,6 +152,10 @@ impl Error {
       Error::HttpStatus(status, url) => {
         let body = format!("Error requesting {url}: {status}");
         (StatusCode::BAD_GATEWAY, body)
+      }
+      Error::SourceTemplateValidation { .. }
+      | Error::MissingSourceTemplatePlaceholder(_) => {
+        (StatusCode::BAD_REQUEST, format!("{self}"))
       }
       _ => (StatusCode::INTERNAL_SERVER_ERROR, format!("{self}")),
     }


### PR DESCRIPTION
This PR adds support for placeholders in the source url. This is useful for cases where the portion of source url is dynamic and can be specified when users request for the endpoint. The feature can be considered a pragmatic middle ground between static source and dynamic source.

Implements the feature request in https://github.com/shouya/rss-funnel/issues/137.

Here's an example to demonstrate the usage:

```yaml
endpoints:
  - path: /telegram.xml
    source:
      template: https://bridge.easter.fr/?action=display&bridge=TelegramBridge&username=${username}&format=Atom
      placeholders:
        username: {}
    filters: []
```

For each placeholders, you can define the default value and/or a validation regex:

```yaml
endpoints:
  - path: /telegram.xml
    source:
      template: https://bridge.easter.fr/?action=display&bridge=TelegramBridge&username=${username}&format=Atom
      placeholders:
        username:
          validation: "^\\w+$"
          default: MANJULtoons
    filters: []
```

Then you can request the endpoint with the corresponding parameter like http://127.0.0.1:4080/telegram.xml?username=MANJULtoons.


NOTE: The Inspector UI for this particular source type is unsupported yet. I'm planning for a rewrite of the Inspector UI so before the rewrite the Inspector UI won't keep up with new features.