### PR TITLE
fix: Allow unspecified filters key

### DIFF
--- a/src/server/endpoint.rs
+++ b/src/server/endpoint.rs
@@ -73,6 +73,7 @@ impl EndpointConfig {
 pub struct EndpointServiceConfig {
   #[serde(default)]
   source: Option<SourceConfig>,
+  #[serde(default)]
   filters: FilterPipelineConfig,
   #[serde(default)]
   on_the_fly_filters: bool,

--- a/src/server/image_proxy.rs
+++ b/src/server/image_proxy.rs
@@ -17,7 +17,7 @@ lazy_static::lazy_static! {
 }
 
 pub fn router() -> Router {
-  info!("loaded image proxy: /_image");
+  info!("handling image proxy: /_image");
 
   use tower_http::cors::AllowOrigin;
   let cors = CorsLayer::new()


### PR DESCRIPTION
Previously the `filters` key is required for an `endpoint` definition. Now we have cases where the `filters` are no longer needed:

- endpoints with on-the-fly filters
- endpoints merely meant to proxy upstream feeds (for example, with templated source)

In such cases, we should allow the user to omit the unncessary `filters` key altogether.