### PR TITLE
fix: Build on Windows

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -23,14 +23,17 @@ use crate::util::Result;
 async fn main() -> Result<()> {
   tracing_subscriber::fmt::init();
 
-  tokio::spawn(async {
-    signal_handler().await.expect("Signal handler failed");
-  });
+  if cfg!(unix) {
+    tokio::spawn(async {
+      signal_handler().await.expect("Signal handler failed");
+    });
+  }
 
   let cli = cli::Cli::parse();
   cli.run().await
 }
 
+#[cfg(unix)]
 async fn signal_handler() -> Result<()> {
   use tokio::signal::unix::{signal, SignalKind};
 


### PR DESCRIPTION
The signal handler for graceful shutdown is unix only. This commit removes it for Window builds.