### PR TITLE
refactor: improve source representation

### DIFF
--- a/scripts/watch-dev.sh
+++ b/scripts/watch-dev.sh
@@ -3,7 +3,7 @@
 trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
 
 cargo watch -x build -s 'touch /tmp/.trigger' &
-cargo watch -w /tmp/.trigger -d0 -s 'target/debug/rss-funnel -c ~/.config/rss-funnel-dev/funnel.yaml server' &
+cargo watch -w /tmp/.trigger -d0 -s 'target/debug/rss-funnel -c ~/.config/rss-funnel-dev/funnel.yaml server -w' &
 
 wait
 

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -50,6 +50,9 @@ pub struct FilterContext {
   /// from a relative path.
   base: Option<Url>,
 
+  /// User supplied source (`?source=` query parameter)
+  source: Option<Url>,
+
   /// The maximum number of filters to run on this pipeline
   filter_skip: Option<FilterSkip>,
 
@@ -63,6 +66,7 @@ impl FilterContext {
     Self {
       base: None,
       filter_skip: None,
+      source: None,
       extra_queries: HashMap::new(),
     }
   }
@@ -79,6 +83,10 @@ impl FilterContext {
     &self.extra_queries
   }
 
+  pub fn source(&self) -> Option<&Url> {
+    self.source.as_ref()
+  }
+
   pub fn set_filter_skip(&mut self, filter_skip: FilterSkip) {
     self.filter_skip = Some(filter_skip);
   }
@@ -90,6 +98,7 @@ impl FilterContext {
   pub fn subcontext(&self) -> Self {
     Self {
       base: self.base.clone(),
+      source: None,
       filter_skip: None,
       extra_queries: self.extra_queries.clone(),
     }
@@ -98,6 +107,7 @@ impl FilterContext {
   pub fn from_param(param: &crate::server::EndpointParam) -> Self {
     Self {
       base: param.base().cloned(),
+      source: param.source().cloned(),
       filter_skip: param.filter_skip().cloned(),
       extra_queries: param.extra_queries().clone(),
     }

--- a/src/server/endpoint.rs
+++ b/src/server/endpoint.rs
@@ -279,9 +279,9 @@ impl EndpointService {
   }
 
   pub async fn run(self, param: EndpointParam) -> Result<Feed> {
-    let source = self.find_source(&param.source)?;
     let mut context = FilterContext::from_param(&param);
-    let feed = source
+    let feed = self
+      .source
       .fetch_feed(&context, Some(&self.client))
       .await
       .map_err(|e| Error::FetchSource(Box::new(e)))?;
@@ -309,18 +309,6 @@ impl EndpointService {
     }
 
     Ok(feed)
-  }
-
-  fn find_source(&self, param: &Option<Url>) -> Result<Source> {
-    match &self.source {
-      Source::Dynamic => param
-        .as_ref()
-        .ok_or(Error::Message("missing source".into()))
-        .cloned()
-        .map(Source::from),
-      // ignore the source from param if it's already specified in config
-      source => Ok(source.clone()),
-    }
   }
 
   pub fn config_changed(&self, config: &EndpointServiceConfig) -> bool {

--- a/src/server/web/endpoint.rs
+++ b/src/server/web/endpoint.rs
@@ -65,11 +65,9 @@ pub async fn render_endpoint_page(
       }
 
       section .source-and-config {
-        @if let Some(source) = source {
-          section .source-control {
-            (source);
-            div.loading { (sprite("loader")) }
-          }
+        section .source-control {
+          (source);
+          div.loading { (sprite("loader")) }
         }
 
         details {
@@ -92,11 +90,11 @@ pub async fn render_endpoint_page(
 
 fn source_control_fragment(
   path: &str,
-  source: &Option<Source>,
+  source: &Source,
   param: &Result<EndpointParam, String>,
-) -> Option<Markup> {
+) -> Markup {
   match source {
-    None => Some(html! {
+    Source::Dynamic => html! {
       input
         .hx-included.grow
         type="text"
@@ -111,20 +109,16 @@ fn source_control_fragment(
         hx-target="main"
         hx-select="main"
       {}
-    }),
-    Some(Source::AbsoluteUrl(url)) => Some(html! {
-      div title="Source" .source { (url) }
-    }),
-    Some(Source::RelativeUrl(url)) => Some(html! {
-      div title="Source" .source { (url) }
-    }),
-    Some(Source::Templated(templated)) => Some(html! {
+    },
+    Source::AbsoluteUrl(url) => html! {div title="Source" .source { (url) }},
+    Source::RelativeUrl(url) => html! {div title="Source" .source { (url) }},
+    Source::Templated(templated) => html! {
       div .source-template-container {
         @let queries = param.as_ref().ok().map(|p| p.extra_queries());
         (source_template_fragment(templated, path, queries));
       }
-    }),
-    Some(Source::FromScratch(scratch)) => Some(from_scratch_fragment(scratch)),
+    },
+    Source::FromScratch(scratch) => from_scratch_fragment(scratch),
   }
 }
 

--- a/src/server/web/list.rs
+++ b/src/server/web/list.rs
@@ -34,7 +34,7 @@ pub fn render_endpoint_list_page(root_config: &RootConfig) -> Markup {
 
 fn endpoint_list_entry_fragment(endpoint: &EndpointConfig) -> Markup {
   html! {
-    li ."my-.5" {
+    li {
       p {
         a href={"/_/endpoint/" (endpoint.path.trim_start_matches('/'))} {
           (endpoint.path)
@@ -74,12 +74,12 @@ fn url_path(url: impl TryInto<Url>) -> Option<String> {
   Some(url.path().to_owned())
 }
 
-fn short_source_repr(source: Option<&SourceConfig>) -> Markup {
+fn short_source_repr(source: &SourceConfig) -> Markup {
   match source {
-    None => html! {
+    SourceConfig::Dynamic => html! {
       span .tag.dynamic { "dynamic" }
     },
-    Some(SourceConfig::Simple(url)) if url.starts_with("/") => {
+    SourceConfig::Simple(url) if url.starts_with("/") => {
       let path = url_path(url.as_str());
       let path = path.map(|p| format!("/_/{p}"));
       html! {
@@ -94,7 +94,7 @@ fn short_source_repr(source: Option<&SourceConfig>) -> Markup {
         }
       }
     }
-    Some(SourceConfig::Simple(url)) => {
+    SourceConfig::Simple(url) => {
       let host = url_host(url.as_str()).unwrap_or_else(|| "...".into());
       html! {
         span .tag.simple {
@@ -102,12 +102,12 @@ fn short_source_repr(source: Option<&SourceConfig>) -> Markup {
         }
       }
     }
-    Some(SourceConfig::FromScratch(_)) => {
+    SourceConfig::FromScratch(_) => {
       html! {
         span .tag.scratch title="Made from scratch" { "scratch" }
       }
     }
-    Some(SourceConfig::Templated(_source)) => {
+    SourceConfig::Templated(_source) => {
       html! {
         span .tag.templated title="Templated source" { "templated" }
       }

--- a/src/source.rs
+++ b/src/source.rs
@@ -19,11 +19,13 @@ lazy_static::lazy_static! {
 }
 
 #[derive(
-  JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
+  JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash, Default,
 )]
 #[serde(untagged)]
 /// # Feed source
 pub enum SourceConfig {
+  #[default]
+  Dynamic,
   /// # Simple source
   ///
   /// A source that is a simple URL. A relative path (e.g. "/feed.xml")
@@ -141,6 +143,7 @@ impl Templated {
   JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
 )]
 pub enum Source {
+  Dynamic,
   AbsoluteUrl(Url),
   RelativeUrl(String),
   Templated(Templated),
@@ -192,6 +195,7 @@ impl TryFrom<SourceConfig> for Source {
         validate_placeholders(&config)?;
         Ok(Source::Templated(config))
       }
+      SourceConfig::Dynamic => Ok(Source::Dynamic),
     }
   }
 }
@@ -270,7 +274,9 @@ impl Source {
         let base = context.base_expected()?;
         base.join(path)?
       }
-      Source::Templated(_) | Source::FromScratch(_) => unreachable!(),
+      Source::Templated(_) | Source::FromScratch(_) | Source::Dynamic => {
+        unreachable!()
+      }
     };
 
     let client =

--- a/src/source.rs
+++ b/src/source.rs
@@ -434,6 +434,13 @@ mod serialization {
     use super::*;
 
     #[test]
+    fn test_deserialize_null() {
+      let json = r#"null"#;
+      let config: SourceConfig = serde_json::from_str(json).unwrap();
+      assert_eq!(config, SourceConfig::Dynamic);
+    }
+
+    #[test]
     fn test_deserialize_dynamic() {
       let json = r#""dynamic""#;
       let config: SourceConfig = serde_json::from_str(json).unwrap();

--- a/src/util.rs
+++ b/src/util.rs
@@ -125,7 +125,7 @@ pub enum Error {
   #[error("Failed fetching source: {0}")]
   FetchSource(Box<Error>),
 
-  #[error("Dynamic source unspecified")]
+  #[error("Source URL unspecified for dynamic source")]
   DynamicSourceUnspecified,
 
   #[error("Source parameter {placeholder} failed to match validation: {validation} (input: {input})")]

--- a/src/util.rs
+++ b/src/util.rs
@@ -125,6 +125,9 @@ pub enum Error {
   #[error("Failed fetching source: {0}")]
   FetchSource(Box<Error>),
 
+  #[error("Dynamic source unspecified")]
+  DynamicSourceUnspecified,
+
   #[error("Source parameter {placeholder} failed to match validation: {validation} (input: {input})")]
   SourceTemplateValidation {
     placeholder: String,


### PR DESCRIPTION
Previously dynamic source is represented as `Option<Source>`. Upon reflection, the case for dynamic source is not semantically the case for the lack of source despite a null source is how dynamic source is represented in config. Therefore, it is better to represent dynamic source as a variant of `Source`.