### PR TITLE
feat: js logs on webui

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -57,6 +57,10 @@ pub struct FilterContext {
 
   /// The extra query parameters passed to the endpoint
   extra_queries: HashMap<String, String>,
+
+  /// Logs collected from the filters. None indicates logging is
+  /// disabled.
+  logs: Option<Vec<String>>,
 }
 
 impl FilterContext {
@@ -67,6 +71,7 @@ impl FilterContext {
       filter_skip: None,
       source: None,
       extra_queries: HashMap::new(),
+      logs: None,
     }
   }
 
@@ -100,7 +105,28 @@ impl FilterContext {
       source: None,
       filter_skip: None,
       extra_queries: self.extra_queries.clone(),
+      logs: self.logs.clone(),
     }
+  }
+
+  pub fn log<'a, S>(&mut self, msg: S)
+  where
+    S: Into<std::borrow::Cow<'a, str>>,
+  {
+    if let Some(logs) = &mut self.logs {
+      logs.push(msg.into().into_owned());
+    }
+  }
+
+  pub fn enable_logging(self) -> Self {
+    Self {
+      logs: Some(Vec::new()),
+      ..self
+    }
+  }
+
+  pub fn logs(&self) -> Option<&[String]> {
+    self.logs.as_deref()
   }
 
   pub fn from_param(param: &crate::server::EndpointParam) -> Self {
@@ -109,6 +135,7 @@ impl FilterContext {
       source: param.source().cloned(),
       filter_skip: param.filter_skip().cloned(),
       extra_queries: param.extra_queries().clone(),
+      logs: None,
     }
   }
 

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -108,10 +108,7 @@ impl FilterContext {
     self.source.as_ref()
   }
 
-  pub fn set_filter_skip(&mut self, filter_skip: FilterSkip) {
-    self.filter_skip = Some(filter_skip);
-  }
-
+  #[cfg(test)]
   pub fn set_base(&mut self, base: Url) {
     self.base = Some(base);
   }

--- a/src/filter/js.rs
+++ b/src/filter/js.rs
@@ -189,13 +189,14 @@ impl JsFilter {
 
 #[async_trait::async_trait]
 impl FeedFilter for JsFilter {
-  async fn run(
-    &self,
-    _ctx: &mut FilterContext,
-    mut feed: Feed,
-  ) -> Result<Feed> {
+  async fn run(&self, ctx: &mut FilterContext, mut feed: Feed) -> Result<Feed> {
     self.modify_feed(&mut feed).await?;
     self.modify_posts(&mut feed).await?;
+
+    for log in self.runtime.extract_console_logs().await {
+      ctx.log(log);
+    }
+
     Ok(feed)
   }
 }

--- a/src/filter_pipeline.rs
+++ b/src/filter_pipeline.rs
@@ -56,7 +56,11 @@ impl FilterPipelineConfig {
 }
 
 impl FilterPipeline {
-  pub async fn run(&self, context: FilterContext, feed: Feed) -> Result<Feed> {
+  pub async fn run(
+    &self,
+    context: &mut FilterContext,
+    feed: Feed,
+  ) -> Result<Feed> {
     self.inner.lock().await.run(context, feed).await
   }
 
@@ -127,12 +131,12 @@ impl Inner {
 
   async fn run(
     &self,
-    mut context: FilterContext,
+    context: &mut FilterContext,
     mut feed: Feed,
   ) -> Result<Feed> {
     for (i, filter) in self.filters.iter().enumerate() {
       if context.allows_filter(i) {
-        feed = self.step(i, filter, &mut context, feed).await?;
+        feed = self.step(i, filter, context, feed).await?;
       }
     }
 

--- a/src/js.rs
+++ b/src/js.rs
@@ -5,7 +5,6 @@ mod fetch;
 use std::fs;
 use std::path::PathBuf;
 
-use builtin::Console;
 use rquickjs::loader::{
   BuiltinLoader, BuiltinResolver, FileResolver, Loader, Resolver, ScriptLoader,
 };

--- a/src/js.rs
+++ b/src/js.rs
@@ -5,6 +5,7 @@ mod fetch;
 use std::fs;
 use std::path::PathBuf;
 
+use builtin::Console;
 use rquickjs::loader::{
   BuiltinLoader, BuiltinResolver, FileResolver, Loader, Resolver, ScriptLoader,
 };
@@ -12,7 +13,7 @@ use rquickjs::module::ModuleData;
 use rquickjs::prelude::IntoArgs;
 use rquickjs::promise::Promise;
 use rquickjs::{
-  async_with, AsyncContext, Ctx, FromJs, Function, IntoJs, Value,
+  async_with, AsyncContext, Class, Ctx, FromJs, Function, IntoJs, Value,
 };
 use url::Url;
 
@@ -160,6 +161,20 @@ impl Runtime {
     self
       .context
       .with(|ctx| handle_exception(&ctx, retval))
+      .await
+  }
+
+  pub async fn extract_console_logs(&self) -> Vec<String> {
+    self
+      .context
+      .with(|ctx| {
+        ctx
+          .globals()
+          .get::<_, Class<builtin::Console>>("console")
+          .unwrap()
+          .borrow_mut()
+          .extract_logs()
+      })
       .await
   }
 }

--- a/src/js/builtin.rs
+++ b/src/js/builtin.rs
@@ -13,13 +13,11 @@ pub(super) fn register_builtin(ctx: &Ctx) -> Result<(), rquickjs::Error> {
   Class::<DOM>::define(&ctx.globals())?;
   Class::<Node>::define(&ctx.globals())?;
 
-  ctx
-    .globals()
-    .set("console", Class::instance(ctx.clone(), Console::new())?)?;
+  let console = Class::instance(ctx.clone(), Console::new())?;
+  ctx.globals().set("console", console)?;
 
-  ctx
-    .globals()
-    .set("util", Class::instance(ctx.clone(), Util {})?)?;
+  let util = Class::instance(ctx.clone(), Util {})?;
+  ctx.globals().set("util", util)?;
 
   let fetch_fn = Func::new(Async(fetch));
   ctx.globals().set("fetch", fetch_fn)?;
@@ -29,7 +27,7 @@ pub(super) fn register_builtin(ctx: &Ctx) -> Result<(), rquickjs::Error> {
 
 #[derive(Trace)]
 #[rquickjs::class]
-struct Console {
+pub(super) struct Console {
   aggregated_logs: Vec<String>,
 }
 
@@ -38,6 +36,10 @@ impl Console {
     Self {
       aggregated_logs: Vec::new(),
     }
+  }
+
+  pub(super) fn extract_logs(&mut self) -> Vec<String> {
+    std::mem::take(&mut self.aggregated_logs)
   }
 }
 

--- a/src/js/builtin.rs
+++ b/src/js/builtin.rs
@@ -15,7 +15,7 @@ pub(super) fn register_builtin(ctx: &Ctx) -> Result<(), rquickjs::Error> {
 
   ctx
     .globals()
-    .set("console", Class::instance(ctx.clone(), Console {})?)?;
+    .set("console", Class::instance(ctx.clone(), Console::new())?)?;
 
   ctx
     .globals()
@@ -29,19 +29,36 @@ pub(super) fn register_builtin(ctx: &Ctx) -> Result<(), rquickjs::Error> {
 
 #[derive(Trace)]
 #[rquickjs::class]
-struct Console {}
+struct Console {
+  aggregated_logs: Vec<String>,
+}
+
+impl Console {
+  fn new() -> Self {
+    Self {
+      aggregated_logs: Vec::new(),
+    }
+  }
+}
 
 #[rquickjs::methods]
 impl Console {
-  fn log(&self, value: rquickjs::Value<'_>) -> Result<(), rquickjs::Error> {
+  fn log(&mut self, value: rquickjs::Value<'_>) -> Result<(), rquickjs::Error> {
     let ty = value.type_name();
-    println!("[log] ({ty}) {}", string_repr(value)?);
+    let msg = format!("[log] ({ty}) {}", string_repr(value)?);
+    println!("{msg}");
+    self.aggregated_logs.push(msg);
     Ok(())
   }
 
-  fn error(&self, value: rquickjs::Value<'_>) -> Result<(), rquickjs::Error> {
+  fn error(
+    &mut self,
+    value: rquickjs::Value<'_>,
+  ) -> Result<(), rquickjs::Error> {
     let ty = value.type_name();
-    println!("[error] ({ty}) {}", string_repr(value)?);
+    let msg = format!("[error] ({ty}) {}", string_repr(value)?);
+    println!("{msg}");
+    self.aggregated_logs.push(msg);
     Ok(())
   }
 }

--- a/src/js/builtin.rs
+++ b/src/js/builtin.rs
@@ -34,24 +34,31 @@ struct Console {}
 #[rquickjs::methods]
 impl Console {
   fn log(&self, value: rquickjs::Value<'_>) -> Result<(), rquickjs::Error> {
-    let msg = match value.try_into_string() {
-      Ok(s) => s.to_string()?,
-      Err(v) => format!("[{}] {:?}", v.type_name(), v),
-    };
-
-    println!("[console.log] {}", msg);
+    let ty = value.type_name();
+    println!("[log] ({ty}) {}", string_repr(value)?);
     Ok(())
   }
 
   fn error(&self, value: rquickjs::Value<'_>) -> Result<(), rquickjs::Error> {
-    let msg = match value.try_into_string() {
-      Ok(s) => s.to_string()?,
-      Err(v) => format!("[{}] {:?}", v.type_name(), v),
-    };
-
-    eprintln!("[console.error] {}", msg);
+    let ty = value.type_name();
+    println!("[error] ({ty}) {}", string_repr(value)?);
     Ok(())
   }
+}
+
+fn string_repr(value: rquickjs::Value<'_>) -> Result<String, rquickjs::Error> {
+  let ctx = value.ctx();
+  if let Some(json) =
+    ctx.json_stringify_replacer_space(value.clone(), rquickjs::Undefined, 4)?
+  {
+    return Ok(json.to_string().unwrap());
+  }
+
+  if let Some(string) = value.into_string() {
+    return Ok(string.to_string().unwrap());
+  }
+
+  Ok("unknown value".to_owned())
 }
 
 #[derive(Trace)]

--- a/src/otf_filter.rs
+++ b/src/otf_filter.rs
@@ -64,7 +64,7 @@ impl OnTheFlyFilter {
   pub async fn run(
     &mut self,
     query: OnTheFlyFilterQuery,
-    context: FilterContext,
+    context: &mut FilterContext,
     feed: Feed,
   ) -> Result<Feed, Error> {
     let pipeline = self.update(query).await?;

--- a/src/server/web/endpoint.rs
+++ b/src/server/web/endpoint.rs
@@ -367,7 +367,7 @@ fn render_feed(mut feed: Feed, logs: Option<&[String]>) -> Markup {
       Some(logs) if !logs.is_empty() => {
         details .flash.error.logs {
           summary { "Logs" }
-          div {
+          div style="overflow-x:scroll" {
             @for log in logs {
               { pre { (log) } }
             }

--- a/src/server/web/endpoint.rs
+++ b/src/server/web/endpoint.rs
@@ -6,6 +6,7 @@ use url::Url;
 
 use crate::{
   feed::{Feed, NormalizedPost, Post},
+  filter::FilterContext,
   server::{endpoint::EndpointService, web::sprite, EndpointParam},
   source::{FromScratch, Source},
 };
@@ -266,9 +267,12 @@ async fn fetch_and_render_feed(
   endpoint: EndpointService,
   params: EndpointParam,
 ) -> Markup {
+  let mut context = FilterContext::from_param(&params);
+  context.enable_logging();
+
   html! {
-    @match endpoint.run(params).await {
-      Ok(feed) => (render_feed(feed)),
+    @match endpoint.run_with_context(&mut context, params).await {
+      Ok(feed) => (render_feed(feed, context.logs())),
       Err(e) => {
         div .flash.error {
           header { b { "Failed to fetch feed" } }
@@ -346,7 +350,7 @@ fn render_post(normalized_post: NormalizedPost, post: Post) -> Markup {
   }
 }
 
-fn render_feed(mut feed: Feed) -> Markup {
+fn render_feed(mut feed: Feed, logs: Option<&[String]>) -> Markup {
   let normalized_feed = feed.normalize();
   let posts = feed.take_posts();
 
@@ -358,6 +362,21 @@ fn render_feed(mut feed: Feed) -> Markup {
     @if let Some(description) = &normalized_feed.description {
       p { (description) }
     }
+
+    @match logs {
+      Some(logs) if !logs.is_empty() => {
+        details .flash.error.logs {
+          summary { "Logs" }
+          div {
+            @for log in logs {
+              { pre { (log) } }
+            }
+          }
+        }
+      }
+      _ => {}
+    }
+
     p { (format!("Entries ({}):", normalized_feed.posts.len())) }
 
     @for (norm_post, post) in normalized_feed.posts.into_iter().zip(posts) {


### PR DESCRIPTION
This PR combines two features:

- make `console.{log,error}` outputs more clear (fixes #152)
- show js logs on webui (fixes #71)

Screenshot:

![image](https://github.com/user-attachments/assets/f696d1e4-a146-4202-b0d9-b620f5d81e4b)

Note: due to [the way caching is implemented](https://github.com/shouya/rss-funnel/pull/153), refreshing the webpage without changing the config may skip js evaluation, thus the log may not show up as expected.