### PR TITLE
Support hosting service on non-root path prefix

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,6 +7,7 @@ use url::Url;
 
 use crate::{
   server::{self, EndpointConfig, ServerConfig},
+  util::relative_path,
   ConfigError, Result,
 };
 
@@ -167,7 +168,8 @@ async fn health_check(health_check_config: HealthCheckConfig) -> Result<()> {
     server = format!("http://{server}");
   }
 
-  let url = Url::parse(&server)?.join("/_health")?;
+  let path = relative_path("_health");
+  let url = Url::parse(&server)?.join(&path)?;
   match reqwest::get(url.clone()).await {
     Ok(res) if res.status().is_success() => {
       eprintln!("{server} is healthy");

--- a/src/filter/image_proxy.rs
+++ b/src/filter/image_proxy.rs
@@ -8,7 +8,7 @@ use url::Url;
 use super::{FeedFilter, FeedFilterConfig, FilterContext};
 use crate::{feed::Feed, ConfigError, Error, Result};
 
-const IMAGE_PROXY_ROUTE: &str = "/_image";
+const IMAGE_PROXY_ROUTE: &str = "_image";
 
 #[derive(
   JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,

--- a/src/filter/merge.rs
+++ b/src/filter/merge.rs
@@ -16,6 +16,7 @@ use super::{FeedFilter, FeedFilterConfig, FilterContext};
   JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
 )]
 #[serde(untagged)]
+#[allow(clippy::large_enum_variant)]
 pub enum MergeConfig {
   /// Simple merge with default client and no filters
   Simple(MergeSimpleConfig),

--- a/src/server.rs
+++ b/src/server.rs
@@ -20,7 +20,6 @@ use tower_http::compression::CompressionLayer;
 use tracing::{info, warn};
 
 use crate::{
-  cli::RootConfig,
   util::{self, relative_path},
   Result,
 };

--- a/src/server.rs
+++ b/src/server.rs
@@ -14,7 +14,7 @@ use axum::{
   routing::get,
   Extension, Router,
 };
-use clap::{builder::IntoResettable, Parser};
+use clap::Parser;
 use http::StatusCode;
 use tower_http::compression::CompressionLayer;
 use tracing::{info, warn};

--- a/src/server.rs
+++ b/src/server.rs
@@ -70,8 +70,7 @@ impl ServerConfig {
   }
 
   pub async fn run_without_config(self) -> Result<()> {
-    let config = RootConfig::on_the_fly("/otf");
-    let feed_service = FeedService::try_from(config).await?;
+    let feed_service = FeedService::new_otf().await?;
     let rel_path = relative_path("otf");
     info!(
       "No config detected. Serving automatic on-the-fly endpoint on {rel_path}"

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -6,7 +6,7 @@ use axum::{
 use axum_extra::extract::CookieJar;
 use http::request::Parts;
 
-use crate::util::{self, relative_path};
+use crate::util::relative_path;
 
 use super::feed_service::FeedService;
 

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -6,6 +6,8 @@ use axum::{
 use axum_extra::extract::CookieJar;
 use http::request::Parts;
 
+use crate::util::{self, relative_path};
+
 use super::feed_service::FeedService;
 
 pub struct Auth;
@@ -42,7 +44,8 @@ impl<S: Send + Sync> FromRequestParts<S> for Auth {
 }
 
 fn login() -> Response {
-  Redirect::to("/_inspector/login.html?login_required=1").into_response()
+  let login_path = relative_path("_inspector/login.html?login_required=1");
+  Redirect::to(&login_path).into_response()
 }
 
 #[derive(serde::Deserialize)]
@@ -59,17 +62,18 @@ pub async fn handle_login(
   match feed_service.login(&params.username, &params.password).await {
     Some(session_id) => {
       let cookie_jar = cookie_jar.add(("session_id", session_id));
-      (cookie_jar, Redirect::to("/_inspector/index.html")).into_response()
+      let home_path = relative_path("_inspector/index.html");
+      (cookie_jar, Redirect::to(&home_path)).into_response()
     }
-    _ => Redirect::to("/_inspector/login.html?bad_auth=1").into_response(),
+    _ => {
+      let login_path = relative_path("_inspector/login.html?bad_auth=1");
+      Redirect::to(&login_path).into_response()
+    }
   }
 }
 
 pub async fn handle_logout(cookie_jar: CookieJar) -> Response {
   let cookie_jar = cookie_jar.remove("session_id");
-  (
-    cookie_jar,
-    Redirect::to("/_inspector/login.html?logged_out=1"),
-  )
-    .into_response()
+  let logout_path = relative_path("_inspector/login.html?logged_out=1");
+  (cookie_jar, Redirect::to(&logout_path)).into_response()
 }

--- a/src/server/endpoint.rs
+++ b/src/server/endpoint.rs
@@ -188,7 +188,7 @@ impl EndpointParam {
   }
 
   fn get_base(req: &Parts) -> Option<Url> {
-    if let Some(url) = Self::base_from_env().as_ref() {
+    if let Some(url) = crate::util::app_base_from_env().as_ref() {
       return Some(url.clone());
     }
 
@@ -221,20 +221,6 @@ impl EndpointParam {
     let base = format!("http://{}/", host);
     let base = base.parse().ok()?;
     Some(base)
-  }
-
-  fn base_from_env() -> &'static Option<Url> {
-    use std::env;
-    use std::sync::OnceLock;
-
-    static APP_BASE_URL: OnceLock<Option<Url>> = OnceLock::new();
-    APP_BASE_URL.get_or_init(|| {
-      let var = env::var("RSS_FUNNEL_APP_BASE").ok();
-      var.map(|v| {
-        v.parse()
-          .expect("Invalid base url specified in RSS_FUNNEL_APP_BASE")
-      })
-    })
   }
 }
 

--- a/src/server/feed_service.rs
+++ b/src/server/feed_service.rs
@@ -15,6 +15,7 @@ use crate::{cli::RootConfig, ConfigError};
 
 use super::{endpoint::EndpointService, EndpointConfig};
 
+// can be cheaply cloned.
 #[derive(Clone)]
 pub struct FeedService {
   inner: Arc<RwLock<Inner>>,

--- a/src/server/image_proxy.rs
+++ b/src/server/image_proxy.rs
@@ -12,12 +12,15 @@ use tower_http::cors::CorsLayer;
 use tracing::{info, warn};
 use url::Url;
 
+use crate::util::relative_path;
+
 lazy_static::lazy_static! {
   static ref SIGN_KEY: Box<[u8]> = init_sign_key();
 }
 
 pub fn router() -> Router {
-  info!("handling image proxy: /_image");
+  let image_proxy_path = relative_path("_image");
+  info!("handling image proxy: {image_proxy_path}");
 
   use tower_http::cors::AllowOrigin;
   let cors = CorsLayer::new()

--- a/src/server/web.rs
+++ b/src/server/web.rs
@@ -13,6 +13,8 @@ use http::StatusCode;
 use login::Auth;
 use maud::{html, Markup};
 
+use crate::util::relative_path;
+
 use super::{feed_service::FeedService, EndpointParam};
 
 #[derive(rust_embed::RustEmbed)]
@@ -93,9 +95,11 @@ impl<S> axum::extract::FromRequestParts<S> for AutoReload {
 
 async fn handle_home(auth: Option<Auth>) -> impl IntoResponse {
   if auth.is_some() {
-    Redirect::temporary("/_/endpoints")
+    let endpoints_path = relative_path("_/endpoints");
+    Redirect::temporary(&endpoints_path)
   } else {
-    Redirect::temporary("/_/login")
+    let login_path = relative_path("_/login");
+    Redirect::temporary(&login_path)
   }
 }
 
@@ -147,9 +151,10 @@ fn favicon() -> Markup {
 }
 
 fn sprite(icon: &str) -> Markup {
+  let sprite_path = relative_path("_/sprite.svg");
   html! {
     svg class="icon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" {
-      use xlink:href=(format!("/_/sprite.svg#{icon}"));
+      use xlink:href=(format!("{sprite_path}#{icon}"));
     }
   }
 }

--- a/src/server/web/endpoint.rs
+++ b/src/server/web/endpoint.rs
@@ -9,6 +9,7 @@ use crate::{
   filter::FilterContext,
   server::{endpoint::EndpointService, web::sprite, EndpointParam},
   source::{FromScratch, Source},
+  util::relative_path,
 };
 
 pub async fn render_endpoint_page(
@@ -51,7 +52,8 @@ pub async fn render_endpoint_page(
     body {
       header .header-bar {
         button .left-button {
-          a href="/_/" { "Back" }
+          @let home_path = relative_path("_/");
+          a href=(home_path) { "Back" }
         }
         h2 { (path) }
         button .button title="Copy Endpoint URL" onclick="copyToClipboard()" {
@@ -108,13 +110,14 @@ fn source_control_fragment(
 ) -> Markup {
   match source {
     Source::Dynamic => html! {
+      @let endpoint_path = relative_path(&format!("_/endpoint/{path}"));
       input
         .hx-included.grow
         type="text"
         name="source"
         placeholder="Source URL"
         value=[param.source().map(|url| url.as_str())]
-        hx-get=(format!("/_/endpoint/{path}"))
+        hx-get=(endpoint_path)
         hx-trigger="keyup changed delay:500ms"
         hx-push-url="true"
         hx-indicator=".loading"
@@ -174,6 +177,7 @@ fn source_template_fragment(
       @match fragment {
         Either::Left(plain) => span style="white-space: nowrap" { (plain) },
         Either::Right((name, Some(placeholder))) => {
+          @let endpoint_path = relative_path(&format!("_/endpoint/{path}"));
           @let value=queries.get(name);
           @let default_value=placeholder.default.as_ref();
           @let value=value.or(default_value);
@@ -184,7 +188,7 @@ fn source_template_fragment(
             placeholder=(name)
             pattern=[validation]
             value=[value]
-            hx-get=(format!("/_/endpoint/{path}"))
+            hx-get=(endpoint_path)
             hx-trigger="keyup changed delay:500ms"
             hx-push-url="true"
             hx-include=".hx-included"
@@ -246,9 +250,10 @@ fn render_config_fragment(
     } @else {
       div {
         header { b { "Filters:" } }
+        @let endpoint_path = relative_path(&format!("_/endpoint/{path}"));
         ul #filter-list .hx-included
           hx-vals="js:{...gatherFilterSkip()}"
-          hx-get=(format!("/_/endpoint/{path}"))
+          hx-get=(endpoint_path)
           hx-trigger="click from:.filter-name"
           hx-push-url="true"
           hx-include=".hx-included"

--- a/src/server/web/list.rs
+++ b/src/server/web/list.rs
@@ -7,6 +7,7 @@ use crate::{
   cli::RootConfig,
   server::{web::sprite, EndpointConfig},
   source::SourceConfig,
+  util::relative_path,
 };
 
 pub fn render_endpoint_list_page(
@@ -59,7 +60,10 @@ fn endpoint_list_entry_fragment(endpoint: &EndpointConfig) -> Markup {
   html! {
     li {
       p {
-        a href={"/_/endpoint/" (endpoint.path.trim_start_matches('/'))} {
+        @let normalized_path = endpoint.path.trim_start_matches('/');
+        @let endpoint_path = format!("/_/endpoint/{}", normalized_path);
+        @let endpoint_path = relative_path(&endpoint_path);
+        a href=(endpoint_path) {
           (endpoint.path)
         }
 
@@ -104,7 +108,7 @@ fn short_source_repr(source: &SourceConfig) -> Markup {
     },
     SourceConfig::Simple(url) if url.starts_with("/") => {
       let path = url_path(url.as_str());
-      let path = path.map(|p| format!("/_/{p}"));
+      let path = path.map(|p| relative_path(&format!("_/{p})")));
       html! {
         @if let Some(path) = path {
           span .tag.local {

--- a/src/util.rs
+++ b/src/util.rs
@@ -24,6 +24,17 @@ pub fn is_env_set(name: &str) -> bool {
   matches!(val.as_str(), "1" | "t" | "true" | "y" | "yes")
 }
 
+const DEFAULT_PATH_PREFIX: &str = "/";
+static PATH_PREFIX: LazyLock<Box<str>> = LazyLock::new(|| {
+  std::env::var("RSS_FUNNEL_PATH_PREFIX")
+    .unwrap_or_else(|_| DEFAULT_PATH_PREFIX.to_owned())
+    .into_boxed_str()
+});
+
+pub fn path_prefix() -> &'static str {
+  &*PATH_PREFIX
+}
+
 #[derive(
   JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
 )]
@@ -83,11 +94,12 @@ impl<'a, T> Iterator for SingleOrVecIter<'a, T> {
 }
 
 use std::{
+  cell::{LazyCell, OnceCell},
   hash::Hash,
   num::NonZeroUsize,
   sync::{
     atomic::{AtomicUsize, Ordering},
-    RwLock,
+    LazyLock, RwLock,
   },
   time::{Duration, Instant},
 };

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,5 @@
 mod html;
 
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 use url::Url;
 
 pub use self::html::{convert_relative_url, fragment_root_node_id, html_body};
@@ -69,131 +67,142 @@ mod app_base {
 
 pub use self::app_base::app_base_from_env;
 
-#[derive(
-  JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
-)]
-#[serde(untagged)]
-pub enum SingleOrVec<T> {
-  /// A single entry
-  Single(T),
-  /// A list of entries
-  Vec(Vec<T>),
-}
+mod single_or_vec {
+  use schemars::JsonSchema;
+  use serde::{Deserialize, Serialize};
 
-impl<T> Default for SingleOrVec<T> {
-  fn default() -> Self {
-    Self::empty()
-  }
-}
-
-pub enum SingleOrVecIter<'a, T> {
-  Single(std::iter::Once<&'a T>),
-  Vec(std::slice::Iter<'a, T>),
-}
-
-impl<T> SingleOrVec<T> {
-  pub fn empty() -> Self {
-    Self::Vec(Vec::new())
+  #[derive(
+    JsonSchema, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash,
+  )]
+  #[serde(untagged)]
+  pub enum SingleOrVec<T> {
+    /// A single entry
+    Single(T),
+    /// A list of entries
+    Vec(Vec<T>),
   }
 
-  pub fn into_vec(self) -> Vec<T> {
-    match self {
-      Self::Single(s) => vec![s],
-      Self::Vec(v) => v,
+  impl<T> Default for SingleOrVec<T> {
+    fn default() -> Self {
+      Self::empty()
+    }
+  }
+
+  pub enum SingleOrVecIter<'a, T> {
+    Single(std::iter::Once<&'a T>),
+    Vec(std::slice::Iter<'a, T>),
+  }
+
+  impl<T> SingleOrVec<T> {
+    pub fn empty() -> Self {
+      Self::Vec(Vec::new())
+    }
+
+    pub fn into_vec(self) -> Vec<T> {
+      match self {
+        Self::Single(s) => vec![s],
+        Self::Vec(v) => v,
+      }
+    }
+  }
+
+  impl<'a, T> IntoIterator for &'a SingleOrVec<T> {
+    type Item = &'a T;
+    type IntoIter = SingleOrVecIter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+      match self {
+        SingleOrVec::Single(s) => SingleOrVecIter::Single(std::iter::once(s)),
+        SingleOrVec::Vec(v) => SingleOrVecIter::Vec(v.iter()),
+      }
+    }
+  }
+
+  impl<'a, T> Iterator for SingleOrVecIter<'a, T> {
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+      match self {
+        Self::Single(s) => s.next(),
+        Self::Vec(v) => v.next(),
+      }
     }
   }
 }
 
-impl<'a, T> IntoIterator for &'a SingleOrVec<T> {
-  type Item = &'a T;
-  type IntoIter = SingleOrVecIter<'a, T>;
+pub use self::single_or_vec::SingleOrVec;
 
-  fn into_iter(self) -> Self::IntoIter {
-    match self {
-      SingleOrVec::Single(s) => SingleOrVecIter::Single(std::iter::once(s)),
-      SingleOrVec::Vec(v) => SingleOrVecIter::Vec(v.iter()),
+mod cache {
+  use std::{
+    hash::Hash,
+    num::NonZeroUsize,
+    sync::{
+      atomic::{AtomicUsize, Ordering},
+      RwLock,
+    },
+    time::{Duration, Instant},
+  };
+
+  use lru::LruCache;
+
+  struct Timed<T> {
+    value: T,
+    created: Instant,
+  }
+
+  pub struct TimedLruCache<K: Hash + Eq, V: Clone> {
+    map: RwLock<LruCache<K, Timed<V>>>,
+    misses: AtomicUsize,
+    hits: AtomicUsize,
+    timeout: Duration,
+  }
+
+  impl<K: Hash + Eq, V: Clone> TimedLruCache<K, V> {
+    pub fn new(max_entries: usize, timeout: Duration) -> Self {
+      let max_entries = max_entries.try_into().unwrap_or(NonZeroUsize::MIN);
+      Self {
+        map: RwLock::new(LruCache::new(max_entries)),
+        timeout,
+        misses: AtomicUsize::new(0),
+        hits: AtomicUsize::new(0),
+      }
+    }
+
+    pub fn get_cached(&self, key: &K) -> Option<V> {
+      let mut map = self.map.write().ok()?;
+      let Some(entry) = map.get(key) else {
+        self.misses.fetch_add(1, Ordering::Relaxed);
+        return None;
+      };
+
+      if entry.created.elapsed() > self.timeout {
+        self.misses.fetch_add(1, Ordering::Relaxed);
+        map.pop(key);
+        return None;
+      }
+
+      self.hits.fetch_add(1, Ordering::Relaxed);
+      Some(entry.value.clone())
+    }
+
+    pub fn insert(&self, key: K, value: V) -> Option<()> {
+      let timed = Timed {
+        value,
+        created: Instant::now(),
+      };
+      self.map.write().ok()?.push(key, timed);
+      Some(())
+    }
+
+    // hit, miss
+    #[allow(unused)]
+    pub fn stats(&self) -> (usize, usize) {
+      (
+        self.hits.load(Ordering::Relaxed),
+        self.misses.load(Ordering::Relaxed),
+      )
     }
   }
 }
 
-impl<'a, T> Iterator for SingleOrVecIter<'a, T> {
-  type Item = &'a T;
-
-  fn next(&mut self) -> Option<Self::Item> {
-    match self {
-      Self::Single(s) => s.next(),
-      Self::Vec(v) => v.next(),
-    }
-  }
-}
-
-use std::{
-  hash::Hash,
-  num::NonZeroUsize,
-  sync::{
-    atomic::{AtomicUsize, Ordering},
-    RwLock,
-  },
-  time::{Duration, Instant},
-};
-
-use lru::LruCache;
-
-pub struct Timed<T> {
-  value: T,
-  created: Instant,
-}
-
-pub struct TimedLruCache<K: Hash + Eq, V: Clone> {
-  map: RwLock<LruCache<K, Timed<V>>>,
-  misses: AtomicUsize,
-  hits: AtomicUsize,
-  timeout: Duration,
-}
-
-impl<K: Hash + Eq, V: Clone> TimedLruCache<K, V> {
-  pub fn new(max_entries: usize, timeout: Duration) -> Self {
-    let max_entries = max_entries.try_into().unwrap_or(NonZeroUsize::MIN);
-    Self {
-      map: RwLock::new(LruCache::new(max_entries)),
-      timeout,
-      misses: AtomicUsize::new(0),
-      hits: AtomicUsize::new(0),
-    }
-  }
-
-  pub fn get_cached(&self, key: &K) -> Option<V> {
-    let mut map = self.map.write().ok()?;
-    let Some(entry) = map.get(key) else {
-      self.misses.fetch_add(1, Ordering::Relaxed);
-      return None;
-    };
-
-    if entry.created.elapsed() > self.timeout {
-      self.misses.fetch_add(1, Ordering::Relaxed);
-      map.pop(key);
-      return None;
-    }
-
-    self.hits.fetch_add(1, Ordering::Relaxed);
-    Some(entry.value.clone())
-  }
-
-  pub fn insert(&self, key: K, value: V) -> Option<()> {
-    let timed = Timed {
-      value,
-      created: Instant::now(),
-    };
-    self.map.write().ok()?.push(key, timed);
-    Some(())
-  }
-
-  // hit, miss
-  #[allow(unused)]
-  pub fn stats(&self) -> (usize, usize) {
-    (
-      self.hits.load(Ordering::Relaxed),
-      self.misses.load(Ordering::Relaxed),
-    )
-  }
-}
+pub use self::cache::TimedLruCache;

--- a/src/util.rs
+++ b/src/util.rs
@@ -26,13 +26,16 @@ pub fn is_env_set(name: &str) -> bool {
 
 const DEFAULT_PATH_PREFIX: &str = "/";
 static PATH_PREFIX: LazyLock<Box<str>> = LazyLock::new(|| {
-  std::env::var("RSS_FUNNEL_PATH_PREFIX")
+  let prefix = std::env::var("RSS_FUNNEL_PATH_PREFIX")
     .unwrap_or_else(|_| DEFAULT_PATH_PREFIX.to_owned())
-    .into_boxed_str()
+    .into_boxed_str();
+  assert!(prefix.ends_with("/"));
+  prefix
 });
 
-pub fn path_prefix() -> &'static str {
-  &*PATH_PREFIX
+pub fn relative_path(path: &str) -> String {
+  debug_assert!(!path.starts_with("/"));
+  format!("{}{path}", *PATH_PREFIX)
 }
 
 #[derive(

--- a/src/util.rs
+++ b/src/util.rs
@@ -97,7 +97,6 @@ impl<'a, T> Iterator for SingleOrVecIter<'a, T> {
 }
 
 use std::{
-  cell::{LazyCell, OnceCell},
   hash::Hash,
   num::NonZeroUsize,
   sync::{


### PR DESCRIPTION
fixes #159.


The path prefix is inferred by the following order:

1. The environment `RSS_FUNNEL_PATH_PREFIX` (Example value: `"app/"`), or if unspecified
2. The path of environment `RSS_FUNNEL_APP_BASE`, or if unspecified
3. `"/"`.