### PR TITLE
fix (web): endpoint links in list view

### DIFF
--- a/src/server/web/list.rs
+++ b/src/server/web/list.rs
@@ -61,7 +61,7 @@ fn endpoint_list_entry_fragment(endpoint: &EndpointConfig) -> Markup {
     li {
       p {
         @let normalized_path = endpoint.path.trim_start_matches('/');
-        @let endpoint_path = format!("/_/endpoint/{}", normalized_path);
+        @let endpoint_path = format!("_/endpoint/{}", normalized_path);
         @let endpoint_path = relative_path(&endpoint_path);
         a href=(endpoint_path) {
           (endpoint.path)


### PR DESCRIPTION
#160 introduced a bug where the endpoint links in the list view were not pointing to the right place. This PR fixes that.

fixes #161.