### PR TITLE
Add accept-language header option for config

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -30,6 +30,9 @@ pub struct ClientConfig {
   /// The "accept" header to send with requests
   #[serde(default)]
   pub accept: Option<String>,
+  /// The "accept-language" header to send with requests
+  #[serde(default)]
+  pub accept_language: Option<String>,
   /// The "cookie" header to send with requests (Deprecated, specify "cookie" field instead)
   #[serde(default)]
   pub set_cookie: Option<String>,
@@ -86,6 +89,9 @@ impl ClientConfig {
     let mut header_map = HeaderMap::new();
     if let Some(accept) = &self.accept {
       header_map.append("Accept", accept.try_into()?);
+    }
+    if let Some(accept_language) = &self.accept_language {
+      header_map.append("Accept-Language", accept_language.try_into()?);
     }
 
     if let Some(cookie) = &self.cookie {


### PR DESCRIPTION
Some sites like reddit start blocking with 403 unless there is an accept-language header. 
This adds the option under the `client` config:
```yaml
          client:
            accept_language: en-US,en
            user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:127.0) Gecko/20250101 Firefox/137.0 
```
