### PR TITLE
feat: add inject_css filter + fix OTF structured config parsing

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -3,6 +3,7 @@ pub(crate) mod full_text;
 pub(crate) mod highlight;
 pub(crate) mod html;
 pub(crate) mod image_proxy;
+pub(crate) mod inject_css;
 pub(crate) mod js;
 pub(crate) mod json_to_feed;
 pub(crate) mod limit;
@@ -338,4 +339,5 @@ define_filters!(
   Limit => limit::LimitConfig, "Limit the number of posts";
   Magnet => magnet::MagnetConfig, "Find magnet links in posts";
   ImageProxy => image_proxy::Config, "Rewrite image src to use proxy";
+  InjectCss => inject_css::InjectCssConfig, "Inject CSS styles into post bodies";
 );

--- a/src/filter/inject_css.rs
+++ b/src/filter/inject_css.rs
@@ -1,0 +1,89 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use super::{FeedFilter, FeedFilterConfig, FilterContext};
+use crate::{error::Result, feed::Feed};
+
+#[derive(
+  JsonSchema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash,
+)]
+#[serde(transparent)]
+/// Inject a CSS `<style>` block into the body of each post.
+pub struct InjectCssConfig {
+  css: String,
+}
+
+#[async_trait::async_trait]
+impl FeedFilterConfig for InjectCssConfig {
+  type Filter = InjectCss;
+
+  async fn build(self) -> Result<Self::Filter> {
+    Ok(InjectCss { css: self.css })
+  }
+}
+
+pub struct InjectCss {
+  css: String,
+}
+
+#[async_trait::async_trait]
+impl FeedFilter for InjectCss {
+  async fn run(
+    &self,
+    _ctx: &mut FilterContext,
+    mut feed: Feed,
+  ) -> Result<Feed> {
+    let style_tag = format!("<style>{}</style>", self.css);
+    let mut posts = feed.take_posts();
+    for post in &mut posts {
+      post.modify_bodies(|body| {
+        body.insert_str(0, &style_tag);
+      });
+    }
+    feed.set_posts(posts);
+    Ok(feed)
+  }
+}
+
+#[cfg(test)]
+mod test {
+  use super::*;
+  use crate::test_utils::{assert_filter_parse, fetch_endpoint};
+
+  #[test]
+  fn test_config_inject_css() {
+    let config = r#"
+      inject_css: "body { color: red; }"
+    "#;
+
+    let expected = InjectCssConfig {
+      css: "body { color: red; }".into(),
+    };
+
+    assert_filter_parse(config, expected);
+  }
+
+  #[tokio::test]
+  async fn test_inject_css_filter() {
+    let config = r#"
+      !endpoint
+      path: /feed.xml
+      source: fixture:///sample_atom.xml
+      filters:
+        - inject_css: "body { font-size: 16px; }"
+    "#;
+
+    let mut feed = fetch_endpoint(config, "").await;
+    let posts = feed.take_posts();
+    assert!(!posts.is_empty());
+    for post in &posts {
+      for body in post.bodies() {
+        assert!(
+          body.starts_with("<style>body { font-size: 16px; }</style>"),
+          "body should start with style tag, got: {}",
+          &body[..body.len().min(80)]
+        );
+      }
+    }
+  }
+}

--- a/src/otf_filter.rs
+++ b/src/otf_filter.rs
@@ -104,6 +104,13 @@ fn parse_single(param: &str) -> Result<FilterConfig> {
     anyhow::bail!("{message}");
   };
 
+  // try parse value as YAML; if it's a mapping (structured config), use it directly
+  if let Ok(yaml_value) = serde_yaml::from_str::<Value>(&value)
+    && yaml_value.is_mapping()
+  {
+    return FilterConfig::parse_yaml_value(name, yaml_value);
+  }
+
   // try parse value as number if possible
   if let Ok(num) = Number::from_str(&value) {
     let value = Value::Number(num);
@@ -139,5 +146,14 @@ mod test {
     // empty value are supported
     assert_parse("simplify_html", "simplify_html: {}");
     assert_parse("simplify_html=", "simplify_html: {}");
+    // structured YAML values (field-specific matching)
+    assert_parse(
+      "keep_only=%7Bfield%3A%20title%2C%20contains%3A%20foo%7D",
+      "keep_only: {field: title, contains: foo}",
+    );
+    assert_parse(
+      "discard=%7Bfield%3A%20categories%2C%20matches%3A%20'%5Cd%2B'%7D",
+      "discard: {field: categories, matches: '\\d+'}",
+    );
   }
 }


### PR DESCRIPTION
## Summary

This PR adds a new `inject_css` filter (closes #164) and fixes structured config parsing in OTF filter parameters (closes #144).

### inject_css filter (#164)

Adds a filter that prepends a `<style>` block to the body of each post in a feed. Useful for RSS readers that render HTML but don't give users styling control.

**Configuration:**

```yaml
filters:
  - inject_css: "body { max-width: 40em; font-size: 16px; }"
```

**Implementation follows existing filter conventions:**
- `InjectCssConfig` (transparent newtype over `String`) implements `FeedFilterConfig`
- `InjectCss` implements `FeedFilter`, prepending a `<style>` tag to each post body
- Registered in `define_filters!` macro — one new file, one line in `src/filter.rs`
- Includes unit tests for config parsing and end-to-end feed processing

### OTF structured YAML parsing (#144)

OTF (on-the-fly) filter parameters passed via URL query strings now correctly handle structured YAML mappings. Previously, a parameter like:

```
keep_only=%7Bfield%3A%20title%2C%20contains%3A%20foo%7D
```

...would fail because `parse_single` only attempted number and string coercion. This adds a YAML mapping check before the existing fallbacks, so filters like `keep_only` and `discard` can accept field-specific matching configs through the OTF interface.

Includes test cases for both structured config scenarios.

## Test plan

- [x] `cargo test -- inject_css` — config parsing and feed processing tests pass
- [x] `cargo test -- otf_filter` — structured YAML parsing test passes
- [x] All existing tests unaffected

Signed-off-by: TickTockBent