### PR TITLE
feat: add inject_css filter for styling feed content

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -3,6 +3,7 @@ pub(crate) mod full_text;
 pub(crate) mod highlight;
 pub(crate) mod html;
 pub(crate) mod image_proxy;
+pub(crate) mod inject_css;
 pub(crate) mod js;
 pub(crate) mod json_to_feed;
 pub(crate) mod limit;
@@ -338,4 +339,5 @@ define_filters!(
   Limit => limit::LimitConfig, "Limit the number of posts";
   Magnet => magnet::MagnetConfig, "Find magnet links in posts";
   ImageProxy => image_proxy::Config, "Rewrite image src to use proxy";
+  InjectCss => inject_css::InjectCssConfig, "Inject CSS styles into post bodies";
 );

--- a/src/filter/inject_css.rs
+++ b/src/filter/inject_css.rs
@@ -1,0 +1,89 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use super::{FeedFilter, FeedFilterConfig, FilterContext};
+use crate::{error::Result, feed::Feed};
+
+#[derive(
+  JsonSchema, Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash,
+)]
+#[serde(transparent)]
+/// Inject a CSS `<style>` block into the body of each post.
+pub struct InjectCssConfig {
+  css: String,
+}
+
+#[async_trait::async_trait]
+impl FeedFilterConfig for InjectCssConfig {
+  type Filter = InjectCss;
+
+  async fn build(self) -> Result<Self::Filter> {
+    Ok(InjectCss { css: self.css })
+  }
+}
+
+pub struct InjectCss {
+  css: String,
+}
+
+#[async_trait::async_trait]
+impl FeedFilter for InjectCss {
+  async fn run(
+    &self,
+    _ctx: &mut FilterContext,
+    mut feed: Feed,
+  ) -> Result<Feed> {
+    let style_tag = format!("<style>{}</style>", self.css);
+    let mut posts = feed.take_posts();
+    for post in &mut posts {
+      post.modify_bodies(|body| {
+        body.insert_str(0, &style_tag);
+      });
+    }
+    feed.set_posts(posts);
+    Ok(feed)
+  }
+}
+
+#[cfg(test)]
+mod test {
+  use super::*;
+  use crate::test_utils::{assert_filter_parse, fetch_endpoint};
+
+  #[test]
+  fn test_config_inject_css() {
+    let config = r#"
+      inject_css: "body { color: red; }"
+    "#;
+
+    let expected = InjectCssConfig {
+      css: "body { color: red; }".into(),
+    };
+
+    assert_filter_parse(config, expected);
+  }
+
+  #[tokio::test]
+  async fn test_inject_css_filter() {
+    let config = r#"
+      !endpoint
+      path: /feed.xml
+      source: fixture:///sample_atom.xml
+      filters:
+        - inject_css: "body { font-size: 16px; }"
+    "#;
+
+    let mut feed = fetch_endpoint(config, "").await;
+    let posts = feed.take_posts();
+    assert!(!posts.is_empty());
+    for post in &posts {
+      for body in post.bodies() {
+        assert!(
+          body.starts_with("<style>body { font-size: 16px; }</style>"),
+          "body should start with style tag, got: {}",
+          &body[..body.len().min(80)]
+        );
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds a new `inject_css` filter that prepends a `<style>` block to the body of each post in a feed. Useful for RSS readers that render HTML content but don't provide styling control.

Configuration:

```yaml
filters:
  - inject_css: "body { max-width: 40em; font-size: 16px; }"
```

Follows the existing filter architecture: `InjectCssConfig` implements `FeedFilterConfig`, `InjectCss` implements `FeedFilter`, registered via `define_filters!` macro.

Closes #164

_(Split from #171 per maintainer feedback.)_